### PR TITLE
Add clickable, filterable tags to blog posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -38,10 +38,16 @@ layout: default
                     <td>Slug</td>
                     <td>{{ post.url }}</td>
                 </tr>
-                {% if post.categories.size > 0 %}
+                {% if post.tags.size > 0 %}
                 <tr>
-                    <td>Category</td>
-                    <td>{{ post.categories | join: ", " }}</td>
+                    <td>Tags</td>
+                    <td>
+                        <span class="tag-list">
+                            {% for tag in post.tags %}
+                            <a href="/writing?tag={{ tag | url_encode }}" class="tag">{{ tag }}</a>
+                            {% endfor %}
+                        </span>
+                    </td>
                 </tr>
                 {% endif %}
             </table>

--- a/assets/css/main_style.css
+++ b/assets/css/main_style.css
@@ -473,6 +473,79 @@ a:hover {
     margin-top: 0.2rem;
 }
 
+/* --- Tags --- */
+.tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+}
+
+.tag {
+    display: inline-block;
+    font-size: 0.75rem;
+    padding: 0.1rem 0.4rem;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.tag:visited {
+    color: var(--text-secondary);
+}
+
+.tag:hover {
+    color: var(--text);
+    border-color: var(--text-secondary);
+    text-decoration: none;
+}
+
+.tag-active,
+.tag-active:visited {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--bg);
+}
+
+.tag-active:hover {
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
+    color: var(--bg);
+}
+
+.tag-filter {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    padding: 0.5rem 0;
+    margin-bottom: 0.25rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+#tag-filter-tags {
+    display: inline-flex;
+    gap: 0.35rem;
+    flex-wrap: wrap;
+}
+
+.tag-filter-clear {
+    margin-left: 0.25rem;
+    font-size: 0.85rem;
+}
+
+.post-tags {
+    display: block;
+    margin-top: 0.3rem;
+}
+
+.post-tags .tag {
+    font-size: 0.7rem;
+    margin-right: 0.15rem;
+}
+
 /* --- Author Bio --- */
 .author-bio {
     margin-top: 3rem;

--- a/writing.html
+++ b/writing.html
@@ -12,20 +12,130 @@ redirect_from: /blog.html
             <a href="/blog.xml">Atom feed</a>.
         </p>
 
-        <ul class="post-list">
+        <div class="tag-filter" id="tag-filter" style="display: none;">
+            Filtered by <span id="tag-filter-tags"></span>
+            <a href="/writing" class="tag-filter-clear">(clear all)</a>
+        </div>
+
+        <ul class="post-list" id="post-list">
             {% for post in site.posts %}
-            <li>
+            <li data-tags="{{ post.tags | join: ',' | downcase }}">
                 <a href="{{ post.url }}" title="{{ post.title }}"
                     >{{ post.title }}</a
                 >
                 <span class="post-date">{{ post.date | date: "%b %Y" }}</span>
                 <span class="post-date">&middot; {{ post.content | number_of_words }} words</span>
+                {% if post.tags.size > 0 %}
+                <span class="post-tags">
+                    {% for tag in post.tags %}
+                    <a href="#" class="tag" data-tag="{{ tag | downcase }}">{{ tag }}</a>
+                    {% endfor %}
+                </span>
+                {% endif %}
                 {% if post.post_summary %}
                 <span class="post-summary">{{ post.post_summary }}</span>
                 {% endif %}
             </li>
             {% endfor %}
         </ul>
+
+        <script>
+        (function () {
+            var activeTags = [];
+
+            function getTagsFromURL() {
+                var params = new URLSearchParams(window.location.search);
+                var raw = params.get("tag");
+                if (!raw) return [];
+                return raw.split(",").map(function (t) { return t.trim().toLowerCase(); }).filter(Boolean);
+            }
+
+            function updateURL() {
+                var params = new URLSearchParams(window.location.search);
+                if (activeTags.length > 0) {
+                    params.set("tag", activeTags.join(","));
+                } else {
+                    params.delete("tag");
+                }
+                var newURL = window.location.pathname + (params.toString() ? "?" + params.toString() : "");
+                history.replaceState(null, "", newURL);
+            }
+
+            function filterPosts() {
+                var items = document.querySelectorAll("#post-list li");
+                items.forEach(function (li) {
+                    if (activeTags.length === 0) {
+                        li.style.display = "";
+                        return;
+                    }
+                    var postTags = li.getAttribute("data-tags").split(",");
+                    var match = activeTags.every(function (t) { return postTags.indexOf(t) !== -1; });
+                    li.style.display = match ? "" : "none";
+                });
+            }
+
+            function updateFilterBar() {
+                var filter = document.getElementById("tag-filter");
+                var tagsContainer = document.getElementById("tag-filter-tags");
+                if (activeTags.length === 0) {
+                    filter.style.display = "none";
+                    return;
+                }
+                filter.style.display = "block";
+                tagsContainer.innerHTML = "";
+                activeTags.forEach(function (tag) {
+                    var span = document.createElement("a");
+                    span.href = "#";
+                    span.className = "tag tag-active";
+                    span.textContent = tag + " \u00d7";
+                    span.addEventListener("click", function (e) {
+                        e.preventDefault();
+                        toggleTag(tag);
+                    });
+                    tagsContainer.appendChild(span);
+                });
+            }
+
+            function updateTagHighlights() {
+                document.querySelectorAll("#post-list .tag").forEach(function (el) {
+                    if (activeTags.indexOf(el.getAttribute("data-tag")) !== -1) {
+                        el.classList.add("tag-active");
+                    } else {
+                        el.classList.remove("tag-active");
+                    }
+                });
+            }
+
+            function toggleTag(tag) {
+                var idx = activeTags.indexOf(tag);
+                if (idx === -1) {
+                    activeTags.push(tag);
+                } else {
+                    activeTags.splice(idx, 1);
+                }
+                updateURL();
+                filterPosts();
+                updateFilterBar();
+                updateTagHighlights();
+            }
+
+            // Initialize from URL
+            activeTags = getTagsFromURL();
+            if (activeTags.length > 0) {
+                filterPosts();
+                updateFilterBar();
+                updateTagHighlights();
+            }
+
+            // Handle tag clicks
+            document.getElementById("post-list").addEventListener("click", function (e) {
+                var tagEl = e.target.closest(".tag");
+                if (!tagEl) return;
+                e.preventDefault();
+                toggleTag(tagEl.getAttribute("data-tag"));
+            });
+        })();
+        </script>
     </div>
 
     <div class="sidebar">


### PR DESCRIPTION
## Summary

- Display tags as pill-styled labels in the post sidebar INFO box and on the writing list page
- Tags link to the writing page with a `?tag=` query param for filtering
- Multi-tag select with AND logic: click tags to toggle them on/off, filter bar shows active tags with remove buttons
- URL stays in sync via `history.replaceState` so filtered views are bookmarkable/shareable

## Test plan

- [ ] Verify tags appear in the INFO sidebar on individual post pages
- [ ] Verify tags appear below each post entry on the writing page
- [ ] Click a tag on a post page — should navigate to `/writing?tag=X` with the list filtered
- [ ] Click multiple tags on the writing page — should filter to posts matching all selected tags
- [ ] Click a tag pill in the filter bar to remove it
- [ ] Click "(clear all)" to reset the filter
- [ ] Verify the URL updates as tags are toggled
- [ ] Navigate directly to a multi-tag URL like `/writing?tag=career,reflection` — should work
- [ ] Check light and dark theme styling
- [ ] Check mobile responsive layout