### PR TITLE
Fix "progamming" typo on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@ title: Home
                     target="_blank"
                     >47 Degrees (acq. by Xebia)</a
                 >
-                (functional progamming in Haskell and Scala)
+                (functional programming in Haskell and Scala)
             </li>
             <li>
                 5 years @


### PR DESCRIPTION
Fixes a spelling typo on the homepage: the 47 Degrees / Xebia entry under "Previously" read "functional progamming" and now reads "functional programming".

**Why:** Small copy fix requested for the homepage — an unambiguous, low-risk correction.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*