### PR TITLE
Capture agent sessions in PostHog, and remove Matomo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ ruby file: ".ruby-version"
 gem "jekyll", "~> 4.4"
 gem "jekyll-feed", "~> 0.17"
 gem "jekyll-redirect-from", "~> 0.16"
-gem "jekyll-analytics", "~> 0.1"
 
 # Ruby 3 no longer ships every library Jekyll plugins may assume is present.
 gem "csv", "~> 3.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,6 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
-    jekyll-analytics (0.1.14)
     jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
     jekyll-redirect-from (0.16.0)
@@ -119,7 +118,6 @@ PLATFORMS
 DEPENDENCIES
   csv (~> 3.3)
   jekyll (~> 4.4)
-  jekyll-analytics (~> 0.1)
   jekyll-feed (~> 0.17)
   jekyll-redirect-from (~> 0.16)
   webrick (~> 1.8)

--- a/_config.yml
+++ b/_config.yml
@@ -26,8 +26,3 @@ repository: dmarticus/dmarticus.github.io
 plugins:
   - jekyll-redirect-from
   - jekyll-feed
-  - jekyll-analytics
-
-Matomo:
-  url: https://dylanamartin.matomo.cloud
-  siteId: "1"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -80,6 +80,26 @@
             })(document, window.posthog || []);
             posthog.init("phc_lff2mSdTzwXBjrFxsB4A4SVa9avouSP09dbTG5QjefC", {
                 api_host: "https://s.dylanamartin.com",
+                // By default posthog-js drops every event when navigator.webdriver
+                // is true or the user agent matches its built-in bot list, which
+                // hides agent and browser-automation sessions entirely. Capture
+                // them instead; each event gets $browser_type: 'bot' | 'browser'.
+                opt_out_useragent_filter: true,
+                before_send: function (event) {
+                    if (!event) return event;
+                    var nav = window.navigator;
+                    event.properties = event.properties || {};
+                    // $browser_type alone conflates a headless agent with an SEO
+                    // crawler, so record which signal flagged this event.
+                    if (nav && nav.webdriver) {
+                        event.properties.agent_signal = "webdriver";
+                    } else if (event.properties.$browser_type === "bot") {
+                        event.properties.agent_signal = "ua_blocklist";
+                    } else {
+                        event.properties.agent_signal = "none";
+                    }
+                    return event;
+                },
             });
         </script>
         <!-- End PostHog -->


### PR DESCRIPTION
## Why

Agent and browser-automation sessions were completely invisible in PostHog, and it wasn't obvious why. The site used the default PostHog snippet with no options, and posthog-js's defaults silently discard that traffic — so there was no signal that anything was being dropped.

While in there: Matomo was still loading on every page despite not being used.

## What

**Capture agent sessions.** posthog-js drops *every* event (not just pageviews) when `navigator.webdriver` is true or the user agent matches its built-in bot list. `navigator.webdriver` is true in any CDP-driven browser, which covers essentially every browser-using agent. `opt_out_useragent_filter` turns that off, so the events land labelled with `$browser_type`. A `before_send` hook adds an `agent_signal` property (`webdriver` / `ua_blocklist` / `none`) because `$browser_type: 'bot'` alone can't distinguish a headless agent from an ordinary SEO crawler.

**Remove Matomo** — drops the `jekyll-analytics` plugin, its config block, and the gem. `Refs #23`, which reported it never worked in the first place.

## Trade-off

`$pageview` now includes crawler traffic. Web Analytics already excludes `$browser_type = bot` automatically, but Product Analytics insights need that filter (or `agent_signal = none`) added explicitly.

## Verification

Built in a `ruby:3.3.6` container with bundler in **frozen** mode, matching what `ruby/setup-ruby` does in CI — this is the check that the hand-edited lockfile is consistent, since `deploy.yml` only builds on push to `master` and there's no PR-time build. Confirmed no Matomo or Piwik reference survives in the generated `_site/`.

Then drove the built site with a headless browser, intercepting the ingest requests so nothing reached the real project:

| Scenario | Events sent | `$browser_type` | `agent_signal` |
|---|---|---|---|
| before, headless agent | **0** | — | — |
| before, real browser | 1 | unset | unset |
| after, headless agent (`webdriver`) | 1 | `bot` | `webdriver` |
| after, bot UA only | 1 | `bot` | `ua_blocklist` |
| after, real browser | 1 | `browser` | `none` |

The first row is the bug reproduced; the rest confirm the fix and exercise all three `agent_signal` branches.

## Note

This only covers agents that execute JavaScript. Agents that just fetch the HTML never run the snippet at all, and GitHub Pages exposes no server logs — so that traffic stays invisible regardless.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*