### PR TITLE
Add reading-log pipeline: issue capture, weekly digest PRs, media archive

### DIFF
--- a/.github/workflows/weekly-log.yml
+++ b/.github/workflows/weekly-log.yml
@@ -1,0 +1,47 @@
+name: Weekly reading log
+
+on:
+  schedule:
+    # Sundays at 16:00 UTC (~8-9am Pacific)
+    - cron: "0 16 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
+jobs:
+  weekly-log:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Collect log issues
+        run: gh issue list -R "$GITHUB_REPOSITORY" -l log --state open --limit 100 --json number,title,body,createdAt > /tmp/issues.json
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Build archive entries and digest draft
+        id: build
+        run: ruby scripts/weekly-log.rb /tmp/issues.json
+
+      - name: Open PR
+        if: steps.build.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COUNT: ${{ steps.build.outputs.count }}
+          CLOSES: ${{ steps.build.outputs.closes }}
+          DIGEST_PATH: ${{ steps.build.outputs.digest_path }}
+        run: |
+          branch="reading-log/$(date -u +%Y-%m-%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add _data/log.yml "$DIGEST_PATH"
+          git commit -m "Weekly reading log: $COUNT entries"
+          git push -u origin "$branch"
+          gh pr create \
+            --title "Weekly reading log: $(date -u +'%B %-d')" \
+            --body "$(printf 'Adds %s logged items to the archive and seeds this week'\''s digest draft (`%s`).\n\nCuration checklist:\n- [ ] Trim the digest draft to the favorites and punch up the notes (or delete the file to skip this week)\n- [ ] Replace the TODO summary\n\nMerging closes the logged issues: %s' "$COUNT" "$DIGEST_PATH" "$CLOSES")"

--- a/_data/log.yml
+++ b/_data/log.yml
@@ -1,0 +1,2601 @@
+# Everything I've read, watched, or otherwise engaged with.
+# Historical entries (backfilled from the old media page, past digests, and Letterboxd) have year-only or approximate dates.
+# New entries are appended by .github/workflows/weekly-log.yml — but hand-editing is fine too.
+- date: '2019'
+  type: book
+  title: All the Light We Cannot See
+  creator: Anthony Doerr
+- date: '2019'
+  type: book
+  title: The Gene
+  creator: Siddhartha Mukherjee
+- date: '2019'
+  type: book
+  title: High Output Management
+  creator: Andrew S. Grove
+- date: '2019'
+  type: book
+  title: American Gods
+  creator: Neil Gaiman
+- date: '2019'
+  type: book
+  title: Killers of the Flower Moon
+  creator: David Grann
+- date: '2019'
+  type: book
+  title: Border Songs
+  creator: Jim Lynch
+- date: '2019'
+  type: book
+  title: The Shortest Way Home
+  creator: Pete Buttigieg
+- date: '2019'
+  type: book
+  title: You Shall Know our Velocity!
+  creator: Dave Eggers
+- date: '2019'
+  type: book
+  title: Sirens of Titan
+  creator: Kurt Vonnegut
+- date: '2019'
+  type: book
+  title: REAMDE
+  creator: Neal Stephenson
+- date: '2019'
+  type: book
+  title: Redemption Road
+  creator: John Hart
+- date: '2019'
+  type: book
+  title: AI Superpowers
+  creator: Kai-Fu Lee
+- date: '2019'
+  type: book
+  title: The Overstory
+  creator: Richard Powers
+- date: '2019'
+  type: book
+  title: Pump Six and Other Stories
+  creator: Paolo Bacigalupi
+- date: '2019'
+  type: book
+  title: Where the Crawdads Sing
+  creator: Delia Owens
+- date: '2019'
+  type: book
+  title: Deep Work
+  creator: Cal Newport
+- date: '2019'
+  type: book
+  title: Digital Minimalism
+  creator: Cal Newport
+- date: '2019'
+  type: book
+  title: The Harder They Come
+  creator: TC Boyle
+- date: '2019'
+  type: book
+  title: The Remains of the Day
+  creator: Kazuo Ishiguro
+- date: '2019'
+  type: book
+  title: The Great Alone
+  creator: Kristin Hannah
+- date: '2019'
+  type: book
+  title: The Goldfinch
+  creator: Donna Tartt
+- date: '2019'
+  type: book
+  title: The Gift of Struggle
+  creator: Bob Herrera
+- date: '2019'
+  type: book
+  title: My Sister, the Serial Killer
+  creator: Oyinkan Braithwaite
+- date: '2020'
+  type: book
+  title: Men without Women
+  creator: Haruki Murakami
+- date: '2020'
+  type: book
+  title: Small Great Things
+  creator: Jodi Picoult
+- date: '2020'
+  type: book
+  title: Educated
+  creator: Tara Westover
+- date: '2020'
+  type: book
+  title: Little Fires Everywhere
+  creator: Celeste Ng
+- date: '2020'
+  type: book
+  title: Between the World and Me
+  creator: Ta-Nehisi Coates
+- date: '2020'
+  type: book
+  title: Hard-Boiled Wonderland and the End of the World
+  creator: Haruki Murakami
+- date: '2020'
+  type: book
+  title: The Order of Time
+  creator: Carlo Rovelli
+- date: '2020'
+  type: book
+  title: Sapiens
+  creator: Noah Yuval Harari
+- date: '2020'
+  type: book
+  title: Neuromancer
+  creator: William Gibson
+- date: '2020'
+  type: book
+  title: Little Brother (re-read)
+  creator: Cory Doctorow
+- date: '2020'
+  type: book
+  title: The Three-Body Problem
+  creator: Cixin Liu
+- date: '2020'
+  type: book
+  title: The Dark Forest
+  creator: Cixin Liu
+- date: '2020'
+  type: book
+  title: Burning Chrome
+  creator: William Gibson
+- date: '2020'
+  type: book
+  title: Count Zero
+  creator: William Gibson
+- date: '2020'
+  type: book
+  title: Release It!
+  creator: Michael T. Nygard
+- date: '2020'
+  type: book
+  title: Consider the Lobster and Other Essays
+  creator: David Foster Wallace
+- date: '2020'
+  type: book
+  title: On Writing
+  creator: Steven King
+- date: '2020'
+  type: book
+  title: Zen and the Art of Motorcycle Maintenance
+  creator: Robert M. Pirsig
+- date: '2020'
+  type: book
+  title: Why Nations Fail
+  creator: Daron Acemoglu and James A. Robinson
+- date: '2020'
+  type: book
+  title: Seinfeldia
+  creator: Jennifer Keishin Armstrong
+- date: '2020'
+  type: book
+  title: Dear Girls
+  creator: Ali Wong
+- date: '2020'
+  type: book
+  title: Can't Even
+  creator: Anne Helen Petersen
+- date: '2020'
+  type: book
+  title: Terranauts
+  creator: T.C. Boyle
+- date: '2020'
+  type: book
+  title: The Buried Giant
+  creator: Kazuo Ishiguro
+- date: '2020'
+  type: book
+  title: Liar's Poker
+  creator: Michael Lewis
+- date: '2020'
+  type: book
+  title: The New Wilderness
+  creator: Diane Cook
+- date: '2020'
+  type: book
+  title: The Attention Merchants
+  creator: Tim Wu
+- date: '2020'
+  type: book
+  title: The Southern Book Club's Guide to Slaying Vampires
+  creator: Grady Hendrix
+- date: '2020'
+  type: book
+  title: Leave the World Behind
+  creator: Rumaan Alam
+- date: '2020'
+  type: book
+  title: The Storied Life of A.J. Fikry
+  creator: Gabrielle Zevin
+- date: '2020'
+  type: book
+  title: Hot Water Music
+  creator: Charles Bukowski
+- date: '2020'
+  type: book
+  title: Out Stealing Horses
+  creator: Per Petterson
+- date: '2020'
+  type: book
+  title: Four in the Morning
+  creator: Sy Safransky
+- date: '2020'
+  type: book
+  title: 'The Neil Gaiman Reader: Selected Fiction'
+  creator: Neil Gaiman
+- date: '2020-08-09'
+  type: article
+  title: Investing for Designers and Developers
+  url: https://brianlovin.com/overthought/investing-for-designers-and-developers
+  note: Tech often provides large incomes to younger people who have little experience
+    with making tons of money; this post helps a lot with understanding how to make
+    the most out of that money.
+- date: '2020-08-09'
+  type: article
+  title: The Impact of Toxic Influencers on Communities
+  url: https://intenseminimalism.com/2020/the-impact-of-toxic-influencers-on-communities/
+  note: Scala has some notorious bad actors in the open-source community and this
+    read is a great overview on how to deal with it. Relevant for any community who
+    has struggled with powerful but dangerous influences.
+- date: '2020-08-09'
+  type: article
+  title: Winning the Internet
+  url: https://pudding.cool/projects/newsletter/
+  note: It's a newsletter about newsletters across the internet! V meta.
+- date: '2020-08-09'
+  type: article
+  title: The summer job as we know it is over
+  url: https://www.vox.com/the-highlight/21319985/covid-19-coronavirus-summer-jobs-gig-internship
+  note: I mean, we knew this already.
+- date: '2020-08-09'
+  type: article
+  title: How Ferrero Rocher Chocolates Became a Status Symbol for Immigrants
+  url: https://www.thrillist.com/eat/nation/ferrero-rocher-chocolates-status-symbol-immigrants
+  note: I recommend this piece if you're interested in the power that capitalizing
+    on fortuitous impact can have on a food brand
+- date: '2020-08-09'
+  type: article
+  title: Chuck Norris and Hacking Twitter
+  url: https://themargins.substack.com/p/chuck-norris-and-hacking-twitter
+  note: I recommend this piece if you've ever wondered how big tech companies seem
+    to get hacked so easily.
+- date: '2020-08-09'
+  type: article
+  title: Cloud Computing Is Not the Energy Hog That Had Been Feared
+  url: https://www.nytimes.com/2020/02/27/technology/cloud-computing-energy-usage.html
+  note: Positive news about the improvements in energy efficiency and how these improvements
+    benefit cloud computing.
+- date: '2020-08-09'
+  type: article
+  title: 'CodeGen: Semantic’s improved language support system'
+  url: https://github.blog/2020-08-04-codegen-semantics-improved-language-support-system/
+  note: Amazing post about applying ASTs to represent code as data and query it as
+    such.
+- date: '2020-08-09'
+  type: article
+  title: Adventures with Scala Collections
+  url: https://www.47deg.com/blog/adventures-with-scala-collections/
+  note: Technical deep-dive written by one of my coworkers on the oft-maligned Scala
+    collections library that makes a case for how effective the library is for solving
+    common programming problems at work.
+- date: '2020-08-16'
+  type: article
+  title: The Rise of TikTok and Understanding Its Parent Company ByteDance
+  url: https://turner.substack.com/p/the-rise-of-tiktok-and-understanding
+  note: Deep dive on TikTok. One of the most interesting reads on TikTok that I've
+    ever encountered. Scares the shit out of me.
+- date: '2020-08-16'
+  type: article
+  title: Pinduoduo and Vertically Integrated Social Commerce
+  url: https://turner.substack.com/p/pinduoduo-and-vertically-integrated
+  note: How to build a tech giant. Also scares the shit out of me.
+- date: '2020-08-16'
+  type: article
+  title: 'Oatly: The New Coke'
+  url: https://divinations.substack.com/p/oatly-the-new-coke#
+  note: Oatly probably doesn't care agbout your health.
+- date: '2020-08-16'
+  type: article
+  title: Drive and Listen
+  url: https://driveandlisten.herokuapp.com/
+  note: Traveling in the time of travel bans.
+- date: '2020-08-16'
+  type: article
+  title: The Truth Is Paywalled But The Lies Are Free
+  url: https://www.currentaffairs.org/2020/08/the-truth-is-paywalled-but-the-lies-are-free/
+- date: '2020-08-16'
+  type: article
+  title: Twitter, George Soros, and Porn
+  url: https://themargins.substack.com/p/twitter-george-soros-and-porn
+  note: "(this is my 3rd _Margins_ post in as many weeks; if you like pop finance
+    you should just sub to them already)"
+- date: '2020-08-16'
+  type: article
+  title: GaryVee Is Still Preaching the Hustle Gospel in the Middle of a Pandemic
+  url: https://marker.medium.com/garyvee-is-still-preaching-the-hustle-gospel-in-the-middle-of-a-pandemic-b033b25f0dc
+  note: Just trust me.
+- date: '2020-08-16'
+  type: article
+  title: Software disenchantment
+  url: https://tonsky.me/blog/disenchantment/
+  note: "(an oldie but goodie). There's so much software out there that just hasn't
+    been made well and there's many reasons why (and this post explains a bunch of
+    them) but it's still sad."
+- date: '2020-08-16'
+  type: article
+  title: Can you know too much about your organization?
+  url: https://hbr.org/2019/12/can-you-know-too-much-about-your-organization
+  note: This piece helps shed some light on why you feel disenchanted about working
+    at the same place for a while despite enjoying your day job.
+- date: '2020-08-16'
+  type: article
+  title: 'Dorking: How to find anything on the internet'
+  url: https://www.alec.fyi/dorking-how-to-find-anything-on-the-internet.html
+  note: I use Google all the time and this post is a summary of some useful heuristics
+    on how to Google more efficiently.
+- date: '2020-08-23'
+  type: article
+  title: Open-sourcing Have I Been Pwned
+  url: https://www.troyhunt.com/im-open-sourcing-the-have-i-been-pwned-code-base/
+  note: I loved all of the specifics that Troy Hunt goes into about running a massively
+    successful open-source project.
+- date: '2020-08-23'
+  type: article
+  title: 'Attack of the Clones: TikTok’s Rival Kuaishou Lands in the US'
+  url: https://turner.substack.com/p/attack-of-the-clones-tiktoks-rival
+  note: Ponderous and thorough deep dive of Kuaishou.
+- date: '2020-08-23'
+  type: article
+  title: Open-Source Knowledge
+  url: https://www.swyx.io/speaking/open-source-knowledge/
+  note: Like the above link about learning in public, the author encourages using
+    blogging, speaking, presenting to open-source your knowledge as well as your tech.
+- date: '2020-08-23'
+  type: article
+  title: Gateway Pages prevent PDF Shock
+  url: https://www.nngroup.com/articles/gateway-pages-prevent-pdf-shock/
+  note: PDFs on the internet are still a rough experience and the author encourages
+    alternatives to them.
+- date: '2020-08-23'
+  type: article
+  title: What's the best thing?
+  url: https://best.tomscott.com/
+  note: Fun Tom Scott Project that compares things and shows you how you did against
+    others.
+- date: '2020-08-23'
+  type: article
+  title: sled.rs
+  url: http://sled.rs/perf
+  note: An very thorough read on performance engineering within the context of sled,
+    an open-source DB written in Rust.
+- date: '2020-08-23'
+  type: article
+  title: Steve Yegge's Google Platform rant from 2011
+  url: https://gist.github.com/chitchcock/1281611
+  note: TL;DR Google treats its employees better than its customers and that's why
+    Amazon ate Google's lunch in the cloud platform space.
+- date: '2020-08-23'
+  type: article
+  title: Steve Yegge's Google Deprecation rant from 2020
+  url: https://medium.com/@steve.yegge/dear-google-cloud-your-deprecation-policy-is-killing-you-ee7525dc05dc
+  note: TL;DR it's more of the same from the above post, just 9 years later.
+- date: '2020-08-23'
+  type: video
+  title: Gabriel Gonzalez's talk on marketing Haskell to mainstream programmers
+  url: https://youtu.be/fNpsgTIpODA
+  note: A bunch of good takeaways from marketing not just Haskell, but any non-mainstream
+    technology.
+- date: '2020-08-23'
+  type: article
+  title: Low-Water Mark (part of a series on design patterns for distributed systems)
+  url: https://martinfowler.com/articles/patterns-of-distributed-systems/low-watermark.html
+  note: This post focuses on how to telling logging machinery which portion of the
+    log can be safely discarded to avoid runaway disk storage.
+- date: '2020-08-23'
+  type: article
+  title: Learn in Public
+  url: https://www.swyx.io/writing/learn-in-public/
+  note: Incredibly inspirational post on blogging, writing, speaking, and embracing
+    the public growth that comes therein.
+- date: '2020-08-23'
+  type: article
+  title: On Being a Principal Engineer
+  url: https://blog.dbsmasher.com/2019/01/28/on-being-a-principal-engineer.html
+  note: Silvia Botros talks about the specifics of succeeding as a senior Individual
+    Contributor.
+- date: '2020-08-30'
+  type: article
+  title: Capitalists Or Cronyists
+  url: https://www.profgalloway.com/capitalists-or-cronyists
+  note: If you're looking for some well-reasoned words on why you think the US is
+    bungling things on a massive scale but are pro-capitalism and you can't understand
+    why it's not working in the US, you might find this piece insightful.
+- date: '2020-08-30'
+  type: article
+  title: Is WFH affecting the S&P;?
+  url: https://themargins.substack.com/p/is-wfh-affecting-the-s-and-p
+  note: I recommend this article if you're curious about the affect that WFH has on
+    the stock market
+- date: '2020-08-30'
+  type: article
+  title: United States Corona Corps
+  url: https://www.profgalloway.com/united-states-corona-corps
+- date: '2020-08-30'
+  type: article
+  title: 'GPT-3, Bloviator: OpenAI’s language generator has no idea what it’s talking
+    about'
+  url: https://www.technologyreview.com/2020/08/22/1007539/gpt3-openai-language-generator-artificial-intelligence-ai-opinion/
+  note: If you're super over GPT-3 FUD and want to read an empirical study about GPT-3
+    that isn't just full of bombastic takes, this is a good read. Despite the title,
+    it's not really a hit piece on GPT-3 -- but it does lay out some specific edge
+    cases where GPT-3 fails.
+- date: '2020-08-30'
+  type: article
+  title: between fked and a hard place
+  url: https://annehelen.substack.com/p/between-fked-and-a-hard-place
+  note: This article interviews a bunch of higher education workers across the country
+    to paint a worrying picture of higher education's response to COVID-19 in the
+    US. Solid doomscrolling content.
+- date: '2020-08-30'
+  type: article
+  title: The Friendship that made Google Huge
+  url: https://www.newyorker.com/magazine/2018/12/10/the-friendship-that-made-google-huge
+  note: The story of Jeff Dean and Sanjay Ghemawat at Google. The least gloomy thing
+    I've read in the last 5 months.
+- date: '2020-08-30'
+  type: article
+  title: Insane Story about the Kidnapping of Sultan bin Turki II
+  url: https://www.vanityfair.com/news/2020/08/how-saudi-prince-sultan-disappeared
+- date: '2020-08-30'
+  type: article
+  title: Shadows
+  url: https://www.profgalloway.com/shadows
+  note: Chilling piece on the state of political discourse in the US.
+- date: '2020-08-30'
+  type: article
+  title: Just quit your job at Facebook already
+  url: https://themargins.substack.com/p/facebook-the-pr-firm
+- date: '2020-08-30'
+  type: article
+  title: Formal methods intro
+  url: https://migue.github.io/post/formal-methods-intro/
+  note: I recommend this for anybody who wants to learn more about Formal Verification
+    but is intimidated by some of the methodologies and jargon (i.e. me).
+- date: '2020-08-30'
+  type: article
+  title: But does it help you ship?
+  url: https://thorstenball.com/blog/2020/08/25/but-does-it-help-you-ship/
+  note: Fun read on the actual cost of adding automations.
+- date: '2020-08-30'
+  type: article
+  title: Parser Combinators
+  url: https://bodil.lol/parser-combinators/
+  note: Technical deep dive on writing a parse combinator in Rust from scratch. I
+    recommend it to anyone who's into parsers, programming language, Rust, or any
+    combination of the three.
+- date: '2020-08-30'
+  type: article
+  title: Reachability Modulo Theories
+  url: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/rmt.pdf
+  note: and [A Solver for Reachability Modulo Theories.](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/paper-45.pdf)
+- date: '2020-08-30'
+  type: article
+  title: Empirical Investigation into Programming Language Syntax
+  url: https://www.vidarholen.net/~vidar/An_Empirical_Investigation_into_Programming_Language_Syntax.pdf
+  note: A cool read that attempts to answer the question of "which parts programming
+    language syntax is good and which ones are bad?"
+- date: '2020-08-30'
+  type: article
+  title: Why Efficiency is Dangerous and Slowing Down Makes Life Better
+  url: https://psyche.co/ideas/why-efficiency-is-dangerous-and-slowing-down-makes-life-better
+  note: Click bait title aside, this post makes a compelling case for being cautious
+    about aiming for efficiency at all costs.
+- date: '2020-08-30'
+  type: article
+  title: Don't Ask to Ask, Just Ask
+  url: https://dontasktoask.com/
+  note: 'This piece speaks to my soul: it''s a quick read on a best practice for async
+    communication. Reminds me of [nohello.com](https://www.nohello.com/).'
+- date: '2020-08-30'
+  type: article
+  title: Questions
+  url: https://patrickcollison.com/questions
+  note: Patrick Collison writes some great posts on the big questions he's chewing
+    on. Inspirational stuff.
+- date: '2020-08-30'
+  type: video
+  title: Hack Your Career by Troy Hunt
+  url: https://www.youtube.com/watch?v=-MUhcgXBj_A&t=0s
+  note: As an aspiring independent consultant this is a great watch.
+- date: '2020-08-30'
+  type: article
+  title: Building a Digital Garden
+  url: https://tomcritchlow.com/2019/02/17/building-digital-garden/
+  note: This post inspired me to set up automated processes to share my learning publicly
+    in a consolidated location.
+- date: '2020-09-06'
+  type: article
+  title: The Arc of the Covenant
+  url: https://offtherun.substack.com/p/the-arc-of-the-covenant
+  note: I recommend this piece if you want to get some data on what the fuck is happening
+    in international finance.
+- date: '2020-09-06'
+  type: article
+  title: Microcovid Calculator
+  url: https://www.microcovid.org/calculator
+  note: Play around with your COVID-19 risk level! If you're someone who likes extrapolating
+    risk from incomplete data sets, you'll probably have fun with it. This is a reminder
+    that I am Not A Doctor.
+- date: '2020-09-06'
+  type: article
+  title: Lofi-Player
+  url: https://magenta.tensorflow.org/lofi-player
+  note: Creative project from Google Brain's magenta project that creates lo-fi beeps
+    n boops using RNNs and provides a cute pixelated UI to boot. Not quite robust
+    enough to have running in the background during work to try and flow to, but definitely
+    good for spending a break to play around with it.
+- date: '2020-09-06'
+  type: article
+  title: Amazon Drivers Are Hanging Smartphones in Trees to Get More Work
+  url: https://www.bloomberg.com/news/articles/2020-09-01/amazon-drivers-are-hanging-smartphones-in-trees-to-get-more-work
+  note: Your weekly dose of gig economy dystopia.
+- date: '2020-09-06'
+  type: article
+  title: Hic Sunt Dracones
+  url: https://aelkus.github.io/void/2020/06/01/opening.html
+  note: You'll like this is you're either (a) a doomer neolib who thinks we're on
+    the cusp of societal collapse (b) someone who enjoys dunking on doomer neolibs
+    but you're curious what sort of content they read and share. I'll let you guess
+    which one I am ;)
+- date: '2020-09-06'
+  type: article
+  title: Github Audio
+  url: https://github.audio/
+  note: When paired with mynoise.net you can attain focus bliss
+- date: '2020-09-06'
+  type: article
+  title: What if Facebook is the real silent majority
+  url: https://www.nytimes.com/2020/08/27/technology/what-if-facebook-is-the-real-silent-majority.html
+  note: '"But what sticks out, when you dig in to the data, is just how dominant the
+    Facebook right truly is. Pro-Trump political influencers have spent years building
+    a well-oiled media machine that swarms around every major news story, creating
+    a torrent of viral commentary that reliably drowns out both the mainstream media
+    and the liberal opposition".'
+- date: '2020-09-06'
+  type: article
+  title: Typing is Hard
+  url: https://typing-is-hard.ch/
+  note: This post outlines type checking and decidability in an accessible way. I
+    recommend it to someone who's familiar with the concepts of type systems and can
+    understand the difference between statically and dynamically typed languages but
+    wants to learn more about the subtle differences across popular statically typed
+    langages. If you're into compilers you'll probably like it :)
+- date: '2020-09-06'
+  type: article
+  title: Against Online Tooling
+  url: https://www.jvt.me/posts/2020/09/01/against-online-tooling/
+  note: The TL;DR is that online tools for things like JWT generation, diff checking,
+    or anything else are access points for accidentally leaking sensitive data. The
+    author encourages doing these operations locally as much as possible.
+- date: '2020-09-06'
+  type: article
+  title: How NAT Traversal Works
+  url: https://tailscale.com/blog/how-nat-traversal-works/
+  note: Tailscale is a cool company that is tackling the challenge of building a secure
+    network without needing to rely on sysadmins for each intersection, and their
+    blog is generally great. I recommend this piece if you're curious about the technical
+    specifics of how networked devices actually connect with each other.
+- date: '2020-09-06'
+  type: article
+  title: An Overview on the Science of Function Length
+  url: https://softwarebyscience.com/very-short-functions-are-a-code-smell-an-overview-of-the-science-on-function-length/
+  note: More empirical analysis of software quality, this time trying to answer the
+    hypothesis of whether very short functions are actually a code smell (one of my
+    many pieces that challenges the "clean code" style of programming). I recommend
+    it if you like reading attempted objective analysis of a relatively ambiguous
+    subject.
+- date: '2020-09-06'
+  type: article
+  title: Shell Commands Rewritten in Rust
+  url: https://zaiste.net/posts/shell-commands-rust/
+  note: List of shell utilities (traditionally written in C) that have been re-written
+    and improved in Rust. You'll probably like this if you're into system utilities
+    or are a big Rust fan.
+- date: '2020-09-06'
+  type: article
+  title: Describing Microservices using Modern Haskell
+  url: https://dl.acm.org/doi/pdf/10.1145/3406088.3409018
+  note: This was written by my coworkers and is an example of a formal paper about
+    industry-specific CS (in contrast with formal papers about more theoretical or
+    abstract concepts). I recommend it if you're curious about microservice design
+    using purely functional architectures, and I'm also biased because I work on the
+    Scala version of this library so I think the work is personally cool.
+- date: '2020-09-06'
+  type: article
+  title: Towards rigorous design of domain-specific distributed systems
+  url: https://dl.acm.org/doi/10.1145/2897667.2897674
+  note: So much of modern cloud computing is in distributed systems, and one of the
+    killer apps of domain-specific modeling that many static FP languages do well
+    is the ability to create programmatic DSLs (i.e. NOT yaml) to define complex distributed
+    systems. This paper lays out a potential DSL design using that idea.
+- date: '2020-09-06'
+  type: article
+  title: The Bicycle Threat Model
+  url: http://calpaterson.com/bicycle-threat-model.html
+  note: 'An introduction to threat modeling via a practical example: keeping your
+    bicycle safe in a city. I recommend for anyone who wants a practical example for
+    threat modeling (perhaps to explain to a non-tech-y family member or friend).'
+- date: '2020-09-06'
+  type: article
+  title: The Case of the top secret iPod
+  url: https://tidbits.com/2020/08/17/the-case-of-the-top-secret-ipod/
+  note: Cool read on an internal project at Apple that sheds some insights into what
+    work at one of the most secretive companies in the US is like.
+- date: '2020-09-13'
+  type: article
+  title: SoftBank, Robinhood, and a Margins Singularity
+  url: https://themargins.substack.com/p/softbank-robinhood-and-a-margins
+  note: The best pop-finance you'll read all week imo. This piece attempts to explain
+    what the hell the stock market has been up to during these last few months that's
+    accessible for an everyman. I recommend it to anyone who's curious about why everyone
+    is talking about stonks.
+- date: '2020-09-13'
+  type: article
+  title: Living in Someone Else's Portland
+  url: https://annehelen.substack.com/p/living-in-someone-elses-portland
+  note: I'm obsessed with AHP's _Culture Study_ , so forgive me if I post about it
+    a lot. But this piece resonated with me because it interviewed actual people in
+    Portland to get their perspective on what's happening there, which (of course),
+    is much mellower than entertainment media wants us to believe. As a Seattleite
+    who dealt with this same overblown crap when CHOP was happening, this piece feels
+    vindicating.
+- date: '2020-09-13'
+  type: article
+  title: America Is Trapped in a Pandemic Spiral
+  url: https://www.theatlantic.com/health/archive/2020/09/pandemic-intuition-nightmare-spiral-winter/616204/
+  note: Another awesome COVID-19 piece from Ed Yong, this one focuses on the idea
+    of why it's so hard to feel like you have any stability in US (largely due to
+    systemic gaslight by the institutions meant to protect the US citizens). Good
+    read if you're feeling helpless and you want to assign a mental model towards
+    the helplessness.
+- date: '2020-09-13'
+  type: article
+  title: Timeline of low-temperature technology
+  url: https://en.wikipedia.org/wiki/Timeline_of_low-temperature_technology
+  note: In a world that seems to be heating up constantly, it's interesting to reflect
+    on all the various times where humans moved to a place, set up shop to keep things
+    cold, and innovated.
+- date: '2020-09-13'
+  type: article
+  title: Incomplete List of Mistakes in the Design of CSS
+  url: https://wiki.csswg.org/ideas/mistakes
+  note: I'm into language design and it's cool to see the CSS working group being
+    so transparent in sharing the mistakes that were made when developing the language.
+    CSS is also a very different language than many other programming languages so
+    the fact that many of the mistakes appear syntactic belies the fact that they
+    are often related to the architecture. This list is also interesting to consider
+    if you wanted to work on developing a DSL that transpiles to CSS, for example.
+- date: '2020-09-13'
+  type: article
+  title: Generative Language Modeling for Automated Theorem Proving
+  url: https://arxiv.org/pdf/2009.03393.pdf
+  note: This is a potentially seminal paper from OpenAI that lays the foundation of
+    AI-driven automated theorem proving, which goes a long way towards training AI
+    towards writing software. The ramifications are exciting and terrifying.
+- date: '2020-09-13'
+  type: article
+  title: How can you not be romantic about programming?
+  url: https://thorstenball.com/blog/2020/09/08/how-can-you-not-be-romantic-about-programming/
+  note: I love Thorsten's writings and this blog is a great koan about how cool programming
+    is. Say what you want about tech as an economic or social system, a lot of us
+    got into the industry because of the pure joy of programming, and this read helped
+    rekindle some of that love.
+- date: '2020-09-13'
+  type: article
+  title: Lucid Dreaming with Neural Nets
+  url: https://mikelynch.org/2015/Aug/29/lucid-dreaming-with-neural-nets/
+  note: 'My buddy [Jack](https://twitter.com/JFK_but_lamer) sent me this one and it''s
+    a great little post that showcases what remains my favorite application of Neural
+    Nets: making trippy art in a programmic way. I''m hopeless at fine motor skills
+    but I love that programs like this help people like me make art with nothing but
+    computers and a little creativity.'
+- date: '2020-09-13'
+  type: article
+  title: How to speed up the rust compiler
+  url: https://blog.mozilla.org/nnethercote/2020/09/08/how-to-speed-up-the-rust-compiler-one-last-time/
+  note: The last in a series of 10 posts dating back to 2016 from the principal engineer
+    on the rust compiler. The whole list is worth reading if you're the type of person
+    who's curious about compiler technical details and micro-optimizations.
+- date: '2020-09-13'
+  type: article
+  title: Android build and the journey to the end game
+  url: https://proandroiddev.com/android-build-and-the-journey-to-the-end-game-55c9766325c5
+  note: 'This post is also on micro-optimizations, only this time on a higher-level:
+    it outlines how to speed up an android gradle build. I recommend it to anyone
+    who''s familiar with Android and gradle and is looking to improve the speed of
+    their builds through a few accessible micro-optimizations.'
+- date: '2020-09-13'
+  type: article
+  title: Vocational Awe
+  url: https://annehelen.substack.com/p/vocational-awe
+  note: This piece discusses capitalism's impact in devaluing essential services through
+    the les of American libraries. I recommend it if you're curious about how libraries
+    work in the US and you want to get mad about how little they tend to be valued
+    financially.
+- date: '2020-09-13'
+  type: article
+  title: 'Why software projects take longer than you think: a statistical model'
+  url: https://erikbern.com/2019/04/15/why-software-projects-take-longer-than-you-think-a-statistical-model.html
+  note: I read this a year ago but it came up again in my work Slack today and generated
+    a lot of buzz. I like ErikBern's writing in general and this is one of the few
+    pieces with a "Why X is Y" title that, instead of being a puff piece, tackles
+    an ambiguous problem (project planning) with statistics. I recommend it for any
+    engineer, but especially an engineering manager who's looking to improve their
+    metrics around project planning.
+- date: '2020-09-20'
+  type: article
+  title: When you browse Instagram and find former Australian Prime Minister Tony
+    Abbott's passport number
+  url: https://mango.pdf.zone/finding-former-australian-prime-minister-tony-abbotts-passport-number-on-instagram
+  note: This is the most fun vulnerability disclosure I've ever read. "Alex" is hilarious
+    and their posts are both insightful and a great read.
+- date: '2020-09-20'
+  type: article
+  title: A Robot Wrote this Article
+  url: https://cacm.acm.org/news/247248-a-robot-wrote-this-entire-article-are-you-scared-yet-human/fulltext
+  note: I'm not worried about AGI coming for my job as an engineer just yet, but it's
+    still cool seeing software write an op-ed without any human input.
+- date: '2020-09-20'
+  type: article
+  title: Nothing to see here, folks
+  url: https://heated.world/p/nothing-to-see-here-folks
+  note: The West Coast of the US is extremely on fire currently and it's incredibly
+    hard to ignore; as of writing this my city has some of the worst air quality of
+    all the major west coast cities. This piece makes the case that major media outlets
+    in the US are refusing to acknowledge systemic climate change as a cause for these
+    fires. This type of negligence makes many folks (including yours truly) pretty
+    outraged.
+- date: '2020-09-20'
+  type: article
+  title: It was never enough
+  url: https://www.texasmonthly.com/articles/it-was-never-enough/
+  note: Fun long read from the Texas Monthly that profiles a prolific businessman
+    / erstwhile scam artist who committed the wildest insurance fraud in the history
+    of Texas.
+- date: '2020-09-20'
+  type: article
+  title: A Deep Dive Into the 'Gentrification Font'
+  url: https://www.vice.com/en_us/article/ep499w/gentrification-font-meme-neutraface
+  note: If, like me, you live in a neighborhood where it seems like bougie construction
+    is cropping up everywhere, you may sometimes feel that all new development looks
+    the same. This story sheds some light on how some aspects of new development (such
+    as the typefaces used) are exactly as isomorphic as you may think.
+- date: '2020-09-20'
+  type: article
+  title: An intuition for optics
+  url: https://about.chatroulette.com/posts/optics/
+  note: Tony Morris has written a bunch of intuitions on useful FP Algebraic Data
+    Types over the last few weeks and I finally am getting around to reading them.
+    I wish I'd read them earlier, honestly. If you're keen on trying to understand
+    some genuinely useful FP concepts and their associated algebraic jargon, start
+    here.
+- date: '2020-09-20'
+  type: article
+  title: Thoughts on Haskell in 2020
+  url: https://alpacaaa.net/thoughts-on-haskell-2020/
+  note: This week I read a lot about the "pragmatic" Haskell, which the concept of
+    writing Haskell code that (while maybe not as powerful or fancily-typed as possible)
+    is readable, maintainable, and takes advantages of Haskell's static typing and
+    ergonomics. There's this whole movement called Boring Haskell that's been espousing
+    this concept for years, (see writings from [Fommil](https://medium.com/@fommil/simple-haskell-is-best-haskell-6a1ea59c73b),
+    [Snoyman](https://www.snoyman.com/blog/2019/11/boring-haskell-manifesto), and
+    [Matt Parsons](https://www.parsonsmatt.org/2019/12/26/write_junior_code.html)),
+    but it's still a hard habit to break, especially for people who are drawn to Haskell
+    because of all the type-level abstractions you get to do with it. In my opinion,
+    this post is best-targeted at (a) someone who wants to use Haskell at work and
+    needs some data to help their manager or director sign off on a project or (b)
+    someone who works on an existing Haskell team that's struggling to hire developers
+    with the necessary pre-requisite programming skills to write complex Haskell code.
+- date: '2020-09-20'
+  type: article
+  title: 'Dependent and refinement types: why?'
+  url: https://www.47deg.com/blog/why-types/
+  note: LMAO so I know I just got off my soapbox talking about why simple Haskell
+    is best, but that doesn't mean it's not worth understanding some of the strong
+    types in Haskell so that you can take advantage of them when you code. In this
+    post by my coworker Alejandro, he walks through the benefits of understanding
+    rudimentary types in Haskell and how you can ultimately use dependent types to
+    prove things to the compiler, which leads to writing code that is free of (software)
+    bugs by definition
+- date: '2020-09-20'
+  type: article
+  title: Safe, Expressive Code with Refinement Types
+  url: https://tech.ovoenergy.com/safe-expressive-code-with-refinement-types/
+  note: On the heels of Alejandro's post about the theoretical benefits of refinement
+    types is this post from Gordon Rennie at OVO Energy that goes through an example
+    of how to use refinement types to safely and elegantly handle input validation,
+    which is a problem that is the scourge of many a web developer but, as Rennie
+    argues in this post, is trivial to handle if you use a language that supports
+    refinement types like Scala.
+- date: '2020-09-27'
+  type: article
+  title: TikTok and the new American capitalism - Margins by Ranjan Roy and Can Duruk
+  url: https://themargins.substack.com/p/tiktok-and-the-new-american-capitalism
+  note: My weekly Margins piece, and this one is a doozy.  It focuses on the Oracle/Walmart/TikTok
+    deal the absolutely bare-faced the crony capitalism that it entailed.  I wrote
+    about Scott Galloway's Crony Capitalists piece a few weeks ago and it's interesting
+    to see that same terminology cropping up a few weeks later in a different context.
+- date: '2020-09-27'
+  type: article
+  title: Brunello Cucinelli – On my Om
+  url: https://om.co/2015/04/27/brunello-cucinelli-2/
+  note: I love fashion and I've always been into Brunello Cucinelli, but I never knew
+    how philosophical or interesting the man was.  I kinda stumbled upon this link
+    by accident but I couldn't stop thinking about it all day that I read it.
+- date: '2020-09-27'
+  type: article
+  title: 'Holbert: A Graphical Interactive Proof Assistant Designed for Education'
+  url: https://github.com/liamoc/holbert
+  note: Liam O'Connor is a programming languages researcher in London and they just
+    released a really cool-looking theorem prover that, unlike many automated theorem
+    provers, comes with a graphical component for the visually oriented.  I recommend
+    anyone who's interested in theorem proving or formal verification to check it
+    out.
+- date: '2020-09-27'
+  type: article
+  title: My favorite Rust function
+  url: https://www.brandonsmith.ninja/blog/favorite-rust-function
+  note: I'm working on a lot on parsers at work, so I've got tokenizing on the brain,
+    and this post was a great deep dive into a great Rust function for tokenizing
+    (a function that I learned about in Bodil Stokke's [post](https://bodil.lol/parser-combinators/)
+    about writing a parser in Rust!).  If you're interested in Rust, parsers, or even
+    just clever programming in general, you should check this post out (and Bodil's
+    too!)
+- date: '2020-09-27'
+  type: article
+  title: The 3 Tribes of Programming
+  url: https://josephg.com/blog/3-tribes/
+  note: When researching the author of the previous post I noticed they referenced
+    this article when it came to classifying different types of programmers.  Personally,
+    I don't think anyone fits into a neat box when it comes to programming styles,
+    but this article is a fun read if you enjoy pieces that make you look internally
+    and classify yourself.
+- date: '2020-09-27'
+  type: article
+  title: Make Now Just Lab on Github
+  url: https://github.com/MakeNowJust-Labo
+  note: In reading about parsers in Scala I stumbled onto this guy's Github portfolio,
+    which blew my mind.  You owe it on yourself to check out this body of open-source
+    work.
+- date: '2020-09-27'
+  type: article
+  title: Quine Codes
+  url: https://quine.codes/
+  note: This is the personal website of the aforementioned Github page!  Of course
+    it's one of the coolest personal website I've stumbled upon.
+- date: '2020-09-27'
+  type: article
+  title: 'Abstract Heresies: Tail recursion and debugging'
+  url: https://funcall.blogspot.com/2011/03/tail-recursion-and-debugging.html
+  note: Oh god why didn't the JVM ever care about optimizing tail recursion.
+- date: '2020-09-27'
+  type: article
+  title: Ousterhout's dichotomy
+  url: https://en.wikipedia.org/wiki/Ousterhout's_dichotomy
+  note: I hadn't heard of this concept before but it's an interesting classification
+    of languages.  Personally, I think it's a pretty arbitrary distinction, but at
+    least it got my thinking about how to categorize different types of programming
+    languages.
+- date: '2020-09-27'
+  type: article
+  title: In the computer
+  url: https://chris-martin.org/2020/in-the-computer
+  note: This is my new favorite meta-article on reasoning about program logic.  Whether
+    you're a declarative, imperative, or functional programmer (or any composition
+    of the 3); I imagine you'll get value out of this piece.
+- date: '2020-09-27'
+  type: article
+  title: The Missing OS
+  url: http://addxorrol.blogspot.com/2020/07/the-missing-os.html
+  note: I don't really know much about OS design but this piece was really exciting
+    to me because the ramifications of what's being proposed (an operating system
+    optimized for networked distributed systems, aka a DatacenterOS) would be incredibly
+    impactful in modern computing, especially in open-source.
+- date: '2020-09-27'
+  type: article
+  title: Side Project Marketing Checklist
+  url: https://github.com/portable-cto/side-project-marketing/blob/master/marketing-checklist.md
+  note: One of my big hobbies during the COVID-19 pandemic has been to learn more
+    about (and spend more time working on) side projects, and I found this guide helpful.  It's
+    a bit too thorough for the types of projects I'm currently doing, but it's comprehensive,
+    and I recommend it for anyone who's interested in marketing their side projects
+    and doesn't know where to start.
+- date: '2020-09-27'
+  type: article
+  title: 'PalanThiel: The Uncola'
+  url: https://www.profgalloway.com/palanthiel-the-uncola
+  note: This week's Scott Galloway goes after Palatir, and makes the case that Palantir
+    is an over-valued, over-hyped government services company who's only skill is
+    in losing money at a more impressive rate than the US government itself.
+- date: '2020-09-27'
+  type: article
+  title: Why it is important that software projects fail
+  url: https://www.berglas.org/Articles/ImportantThatSoftwareFails/ImportantThatSoftwareFails.html
+  note: The thesis of this piece is a bit tongue-in-cheek, but basically it comes
+    down to "we need projects to fail so that bureaucrats can relax about their projects
+    failing and maybe address project management with a more realistic scope instead
+    of holding on to success at all costs".
+- date: '2020-10-04'
+  type: article
+  title: Why Is Everything Sold Out Right Now?
+  url: https://www.theatlantic.com/technology/archive/2020/09/pandemic-broke-online-shopping/616353/
+  note: A lot has been written on how the woeful American response to the COVID-19
+    pandemic, but one of the areas that almost consumers can relate to is that it
+    seems as though we have a shortage of _everything_ when it comes to shopping online.  If
+    you, like me, are curious as how how these shortages came to be, you'll find this
+    piece interesting.
+- date: '2020-10-04'
+  type: article
+  title: The Conflict is the Point
+  url: https://themargins.substack.com/p/the-conflict-is-the-point
+  note: 'This piece is an excellent summary of the relationship between virality and
+    "earned audience" that comes with creating conflict online.  My favorite quote:
+    "Whether you’re an individual writer looking to boost your profile or a private-equity
+    fueled global fast food conglomerate, everyone is being trained in the easiest
+    of hacks. Stoke conflict. Be kind of a dick. Go at someone. If there’s no one
+    to go at, build a strawman. Or just subtweet no one. Whatever you do, structure
+    your communication in a conflict or the feeds won’t listen."'
+- date: '2020-10-04'
+  type: article
+  title: Jenna Wortham
+  url: https://om.co/2015/03/03/jenna-wortham-new-york-times-writer/
+  note: I'm really digging Om Malik's writings lately; last week I posted a piece
+    on Brunello Cucinelli, and this week I went into the archives for a great read
+    on Jenna Wortham, who's NYT podcast (_Still Processing_) I've been loving during
+    the pandemic.  Non-technically, totally fun read.
+- date: '2020-10-04'
+  type: article
+  title: Taco Bell Quarterly Volume III
+  url: https://tacobellquarterly.org/volume-3-fall-2020/
+  note: Just trust me.  TBQ is the coolest, edgiest, and most accessible lit quarterly
+    I've found on the internet.
+- date: '2020-10-04'
+  type: article
+  title: The Lifestyle Blog Voter
+  url: https://annehelen.substack.com/p/the-lifestyle-blog-voter
+  note: Fascinating on the precariousness of middle-class life through the lens of
+    Lifestyle Blog Trump voters.
+- date: '2020-10-04'
+  type: article
+  title: Neural Networks, Types, and Functional Programming
+  url: http://colah.github.io/posts/2015-09-NN-Types-FP/
+  note: Okay honestly I haven't read this yet but I love everything in the title so
+    just trust me on it I hope.
+- date: '2020-10-04'
+  type: article
+  title: The Dark Secrets of Fast Compilation for Kotlin
+  url: https://blog.jetbrains.com/kotlin/2020/09/the-dark-secrets-of-fast-compilation-for-kotlin/
+  note: Kotlin is a interesting language for a lot of reasons, but one of my favorite
+    attributes about the language is that it was designed for industrial programming
+    -- meaning it's optimized for large codebases with many users that grow over time.  As
+    a result, one of the things that it needed was an optimizing compiler so that
+    compilation time didn't become untenable as the codebase grew.  This blog post
+    from Jetbrains outlines many of the tradeoffs that they considered when designing
+    Kotlin's optimizing compiler, and is a good read for not only compiler nerds,
+    but any engineer who has to think hard about tradeoffs.
+- date: '2020-10-04'
+  type: article
+  title: My Least Favorite Rust Type
+  url: https://ridiculousfish.com/blog/posts/least-favorite-rust-type.html
+  note: A fun counterpoint to my post last week on "My Favorite Rust function", this
+    piece explains why Rust's `std::ops::Range` type is full of confusing features.  As
+    a language designer, it's fascinating to think about how users will interact with
+    programming languages and posts like this are a good reminder on the things that
+    improve language ergonomics.
+- date: '2020-10-04'
+  type: article
+  title: Void Is a Smell
+  url: https://tech.freckle.com/2020/09/23/void-is-a-smell/
+  note: This is a Haskell post, but the idea that functions that return nothing (i.e.
+    perform side-effects) are a code smell is an important idea that I think is worth
+    considering in _any_ language.
+- date: '2020-10-04'
+  type: article
+  title: Annoying things in Scala 2 that'll be mostly gone in Scala 3
+  url: https://blog.softwaremill.com/annoying-things-in-scala-2-thatll-be-mostly-gone-in-scala-3-e1479a6d855c
+  note: 'Scala 3 represents a massive paradigm shift for the Scala language and this
+    post lays out some of the best new features that the latest version will introduce.  Among
+    them are:'
+- date: '2020-10-04'
+  type: article
+  title: Lambda Pi
+  url: https://www.andres-loeh.de/LambdaPi/LambdaPi.pdf
+  note: This is a really nice (haskell) tutorial by Andres Loh, Conor McBride, and
+    Wouter Swierstra that is demonstrates minimal implementation of Lambda PI (STLC
+    + dependent types).  It's only 30 pages but really clean and easy to read.  If
+    you like Haskell, or even just formal verification, you'll have fun with this.  The
+    progressions goes as follows;
+- date: '2020-10-04'
+  type: article
+  title: On Browser Tabs
+  url: https://abuqader.substack.com/p/on-browser-tabs
+  note: A quick read that talks about the "seeking circuit" that many of us manufacture
+    when we open (and save) a bunch of browser tabs.
+- date: '2020-10-04'
+  type: article
+  title: Why senior engineers get nothing done
+  url: https://swizec.com/blog/why-senior-engineers-get-nothing-done/
+  note: Honestly I liked this post because it validated my experience at my previous
+    company as a senior engineer who "couldn't get anything done".
+- date: '2020-10-11'
+  type: article
+  title: Why is Snowflake so Valuable?
+  url: https://www.freshpaint.io/blog/why-is-snowflake-so-valuable
+  note: 'This piece makes the case that the high valuation of Snowflake is largely
+    due to strong performance in the following 5 metrics: (1) Growth (2) Net Retention
+    (3) Net Promoter Score (NPS) (4) Average Contract Value and (5) Net Loss.  At
+    my old company we frequently measured our success against these 5 metrics as well,
+    as we ended up with a similar result to Snowflake where we were acquired at a
+    valuation that about 10x''d our revenue.  Our numbers weren''t as insane as Snowflake,
+    but these metrics seem  like a pretty good gold standard for a SaaS company valuation.'
+- date: '2020-10-11'
+  type: article
+  title: For a Good Time, Call
+  url: https://www.guernicamag.com/for-a-good-time-call/
+  note: A story of two young women and growing up in Las Vegas in the early 2000s,
+    told through stories on the party line.  I'd never heard of party lines until
+    [this podcast](https://podcasts.apple.com/nz/podcast/p-line/id1522337888?i=1000485162923)
+    from California Love, and now this is the second story in less than a month I've
+    read about them.  I missed this train as a kid, lol.
+- date: '2020-10-11'
+  type: article
+  title: How normal am I?
+  url: https://www.hownormalami.eu/
+  note: 'This website is an experiment from Dutch privacy researcher Tijmen Schep
+    that tries to codify how normal your online profile is based on ~20 key demographics.  It''s
+    pretty shocking to see how much data is colected about you in the process of browsing
+    the internet, and this piece is a sobering reminder about all the privacy many
+    internet users willingly give up to be online.  If this subject matter interests
+    you, Schep has another site that I recommend checking out: [Social Cooling](https://www.socialcooling.com/).'
+- date: '2020-10-11'
+  type: article
+  title: 'Things I Was Wrong About: Types — Sympolymathesy, by Chris Krycho'
+  url: https://v5.chriskrycho.com/journal/things-i-was-wrong-about/1-types/
+  note: I'm really into strongly-typed languages, so this piece was a fun read for
+    me to challenge my assumption that strong typing is _always_ a good thing for
+    a programming languages.  The major takeways from the author are that the 3 major
+    benefits of type systems in a language are (1) type inference, (2) type soundness,
+    and (3) sum/tagged union types.
+- date: '2020-10-11'
+  type: article
+  title: The Era of Visual Studio Code
+  url: https://blog.robenkleene.com/2020/09/21/the-era-of-visual-studio-code/
+  note: I write a ton of content on VSCode (including this blog!), and it's pretty
+    amazing to see the dominance of this editor among developers in the last decade.  VSCode
+    is a great example of how powerful an editor can become when a powerful company
+    focuses on the right things and aggressively innovates on them.
+- date: '2020-10-11'
+  type: article
+  title: I was wrong. CRDTs are the future
+  url: https://josephg.com/blog/crdts-are-the-future/
+  note: I'm still trying to understand this piece (and the [original talk](https://www.youtube.com/watch?v=x7drE24geUw)
+    about [Conflict-free replicated data types](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type)
+    from Martin Kleppmann), but it's exciting to see all of the breakthrough happening
+    in distributed computing, since I'm a big believe that the future of software
+    will continue to be distributed.
+- date: '2020-10-18'
+  type: article
+  title: 5 tips for writing great client SDK libraries
+  url: https://medium.com/wix-engineering/5-tips-for-writing-great-client-libraries-f6d02d57fdcc
+  note: Wix has a great engineering blog, especially for Scala-related work, and I
+    recommend this guide to anyone looking to write an open-source library in Scala
+    and doesn't know where to start.  (I'm also writing a blog post about getting
+    started in open-source, so stay tuned!)
+- date: '2020-10-18'
+  type: article
+  title: Mu-Haskell 0.4 Released
+  url: https://www.47deg.com/blog/mu-haskell-0-4/
+  note: This is a bit of a biased article but I work on the mu ecosystem at 47 Degrees
+    and my Haskell coworkers just released an excellent addition to the library.  This
+    piece is a good complement to the Sam Halliday article because it talks a lot
+    about the practical benefits of using mu with Haskell to build a modern distributed
+    microservice without adding too much complexity.
+- date: '2020-10-18'
+  type: article
+  title: Rewriting the Technical Interview
+  url: https://aphyr.com/posts/353-rewriting-the-technical-interview
+  note: Aphyr has written several hilarious posts about tech interviewing that are
+    as technical and brilliant as they are entertaining.  Each one is a treat to read.  Here's
+    their newest :)
+- date: '2020-10-18'
+  type: article
+  title: The Pyramid Principle
+  url: https://medium.com/lessons-from-mckinsey/the-pyramid-principle-f0885dd3c5c7
+  note: I recommend this to anyone who's looking to level up their communications
+    game (which should be almost everyone -- good communication skills are absolutely
+    worth their weight in gold in tech).  The Pyramid Principle is a tried-and-true
+    McKinsey practice for effective communicating complex topics.
+- date: '2020-10-18'
+  type: article
+  title: Daniel Ek
+  url: https://www.theobservereffect.org/daniel.html
+  note: The Observer Effect is a new site I've found that does longform interviews
+    with tech leaders.  I enjoyed this profile on Spotify's Daniel Ek, I love how
+    much Daniel empowers his team around him to make good decisions and how that empowerment
+    frees up time for him to focus on the future (he mentions that he's currently
+    focused on 2025, which is crazy to think about).
+- date: '2020-10-18'
+  type: article
+  title: Delivering with Haskell
+  url: https://medium.com/@fommil/delivering-with-haskell-a347d8359597
+  note: Sam Halliday (@fommil) is an excellent writer and very knowledgeable about
+    FP, especially Haskell.  I recommend this piece for anyone who's looking for some
+    guiding principles about being an effective industrial engineering team with Haskell
+    (or for anyone who _wants_ to be an industrial engineering team with Haskell).
+- date: '2020-10-25'
+  type: article
+  title: The Island That Humans Can’t Conquer
+  url: https://www.hakaimagazine.com/features/the-island-humans-cant-conquer/
+  note: Humans can only live in a comparatively small range of climates on the planet,
+    and I find it interesting to see how we've pushed those boundaries throughout
+    human history.  If you find that interesting, too, you'll probably like this.
+- date: '2020-10-25'
+  type: article
+  title: Johns Hopkins Poker Course
+  url: https://hopkinspokercourse.com/
+  note: I loved this link!  If you've ever wanted to improve your poker playing skills
+    (and, by extension, your betting abilities) through a grounding in first principles,
+    Avi Rubin's course provides a thorough overview of how you can do that (the only
+    thing to really do after, of course, is practice).
+- date: '2020-10-25'
+  type: article
+  title: Why Life Can’t Be Simpler
+  url: https://fs.blog/2020/10/why-life-cant-be-simpler/
+  note: The answer, of course, is because the "simplest" things are the things that
+    require the least amount of assumptions, which are some of the hardest things
+    in the world to actually find.
+- date: '2020-10-25'
+  type: article
+  title: This website is killing the planet
+  url: https://visitmy.website/2020/07/13/this-website-is-killing-the-planet/
+  note: Just trust me.
+- date: '2020-10-25'
+  type: article
+  title: 'Orbital Edge Computing: Nanosatellite Constellations as a New Class of Computer
+    System'
+  url: https://abstract.ece.cmu.edu/pubs/oec-asplos2020.pdf
+  note: This paper is a wild ride into the world of true "edge computing" as it outlines
+    some of the interesting approaches used by semi-autonomous micro-satellites that
+    work together to send information to space to earth with limited bandwidth.
+- date: '2020-10-25'
+  type: article
+  title: The Case for a Learned Sorting Algorithm
+  url: https://dl.acm.org/doi/10.1145/3318464.3389752
+  note: Sorting is one of _the_ classic problems in computer science and this paper
+    provides some interesting benchmarks for a new type of ML-driven sorting algorithm
+    that significantly outperforms RadixSort on a massive (1 billion item) dataset,
+    and that performance _includes_ time to train the model.  This is a pretty exciting
+    result for anyone interested in sorting data at a large scale.
+- date: '2020-10-25'
+  type: article
+  title: Effect Runtime
+  url: https://alexn.org/snippets/2020/10/12/effect-runtime.html
+  note: and [Generic IOApp alternative](https://alexn.org/snippets/2020/10/15/generic-ioapp-alternative.html).  Alexandru
+    Nedelcu is an excellent Scala engineer and prolific writer, and these two pieces
+    are great foundations (with plenty of example code) for understanding how to build
+    pure IOApps and effect runtimes using Cats and Cats-Effect.  If you're interested
+    in pure FP for Scala, understanding this is the equivalent to a 101 course, and
+    Alex makes it really easy to grok.
+- date: '2020-10-25'
+  type: article
+  title: 'Signals and Threads: Python, OCaml, and Machine Learning'
+  url: https://signalsandthreads.com/python-ocaml-and-machine-learning/
+  note: 'and [Signals and Threads: Language Design](https://signalsandthreads.com/language-design/).  Signals
+    and Threads is my favorite podcast in tech right now: Ron Minsky is an engaging
+    and enthusiastic host and he has a plethora of incredible engineering talent at
+    Jane Street to pull information from.  This weeks podcasts covered my two areas
+    of programming interest: language design, and machine learning, and I especially
+    enjoyed both of them.'
+- date: '2020-10-25'
+  type: article
+  title: 'GitHub - danluu/post-mortems: A collection of postmortems'
+  url: https://github.com/danluu/post-mortems
+  note: Dan Luu is a great writer and teacher of industrial software engineering and
+    this repo is a cool collection of postmortems published by a variety of different
+    industries.  If you work in operations at all, postmortems are an unfortunate
+    but vital part of the job, and this cache of postmortems makes for great inspiration
+    when it comes to designing and implementing a postmortem process.
+- date: '2020-10-25'
+  type: article
+  title: SEO mistakes I've made and how I fixed them
+  url: https://blog.maximeheckel.com/posts/seo-mistakes-i-have-made-and-how-i-fixed-them
+  note: I'm pretty new to the blogging game but even I recognize the importance that
+    good SEO can have on getting my posts in front of a wider audience.  This article
+    provides a great summary on low-hanging SEO fruit for your blog or website that
+    can be tackled without making any major changes to your content production flow.
+- date: '2020-11-01'
+  type: article
+  title: Inside Foxconn’s empty buildings, empty factories, and empty promises in
+    Wisconsin
+  url: https://www.theverge.com/21507966/foxconn-empty-factories-wisconsin-jobs-loophole-trump
+  note: You should listen to this [Reply All](https://gimletmedia.com/shows/reply-all/wbhjwd)
+    podcast before reading this piece :)
+- date: '2020-11-01'
+  type: article
+  title: Facebook is censoring me
+  url: https://themargins.substack.com/p/facebook-is-censoring-me
+  note: Delete your Facebook account.
+- date: '2020-11-01'
+  type: article
+  title: 'Ghislaine Maxwell deposition redactions: How to crack them'
+  url: https://slate.com/news-and-politics/2020/10/ghislaine-maxwell-deposition-redactions-epstein-how-to-crack.html
+  note: Fascinating read on how to decode censorship patterns used by the secret service
+    when redacting public information, and then applying those decoding techniques
+    to decode the Ghisliane Maxwell deposition.
+- date: '2020-11-01'
+  type: article
+  title: Meet the Excel warriors saving the world from spreadsheet disaster
+  url: https://www.wired.co.uk/article/spreadsheet-excel-errors
+  note: Just trust me.
+- date: '2020-11-01'
+  type: article
+  title: Notes on My Colon Cancer
+  url: https://www.charlieharrington.com/colon-cancer
+  note: This piece was a fun read on decidedly not fun topic topic.  I'd never heard
+    of this author before, but his candor in writing about such an intense topic drew
+    me in and makes me want to read more of his writing.  Definitely worth a read
+    if you need a refresher on things to be grateful for.
+- date: '2020-11-01'
+  type: article
+  title: Life & Death
+  url: https://www.profgalloway.com/life-death
+  note: Another intense read about intense subject matter, this piece is Scott Galloway
+    at my favorite -- he gets deep to the human element of a reader question and dispenses
+    sage advice on how to deal with the passing of a parent.  Having lost my Grandmother
+    recently and gone through both my own grief and the secondhalf grief of my parents
+    during this time, this piece rang especially true for me.
+- date: '2020-11-01'
+  type: article
+  title: 'Helios: Hyperscale Indexing for the Cloud & Edge'
+  url: http://www.vldb.org/pvldb/vol13/p3231-potharaju.pdf
+  note: Deep dive into the details of Helios, a distributed, highly-scalable system
+    used at Microsoft for flexible ingestion, indexing, and aggregation of large streams
+    of real-time data that is designed to plug into relationals engines.  As an ingestion
+    and indexing system, Helios separates ingestion and indexing and introduces a
+    novel bottoms-up index construction algorithm. It exposes tables and secondary
+    indices for use by relational query engines through standard access path selection
+    mechanisms during query optimisation. As a reference blueprint, Helios’ main feature
+    is the ability to move computation to the edge.
+- date: '2020-11-01'
+  type: article
+  title: virtualizing a hackathon at ScalaMatsuri 2020
+  url: https://eed3si9n.com/virtualizing-hackathon-at-scalamatsuri2020
+  note: A report of running a virtual hackathon at ScalaMatsuri Day 2 Unconference.
+- date: '2020-11-01'
+  type: article
+  title: Timekeeping in Financial Exchanges
+  url: https://lucaspauker.ml/articles/20
+  note: This piece challenges the reader to think about the difficulties of clock
+    synchronization in distributed architectures.  Makes for a great read when coupled
+    with [this podcast from Signals and Threads](https://signalsandthreads.com/clock-synchronization/).
+- date: '2020-11-01'
+  type: article
+  title: 'Advice to my young self: to succeed in your career, forget side projects
+    and focus on your job'
+  url: https://manuel.darcemont.fr/posts/focus-on-jour-job/
+  note: 'I really needed to read this post this past week.  I''ve been spending a
+    ton of time lately working on my side project and I''ve found myself burning out
+    at both my day job and my side project.  Despite the title of this post: this
+    blog doesn;t encourage readers to quit their side hustles, but simply asks them
+    to consider if the opportunity cost of working on a side project is worth the
+    tradeoff of excelling in their existing day job.  Many of us tend to write off
+    the benefits that come from doing your day job well.'
+- date: '2020-11-01'
+  type: article
+  title: 'Talking, Typing, Thinking: Software Is Not a Desk Job'
+  url: https://daniel.fone.net.nz/blog/2020/10/21/talking-typing-thinking-software-is-not-a-desk-job/
+  note: As a software consultant, I don't bill my clients for the time spent thinking
+    in the shower, but this post convinces me that maybe I _should_ ;)
+- date: '2020-11-01'
+  type: article
+  title: Applying Textbook Data Structures for Real Life Wins
+  url: https://heap.io/blog/engineering/applying-textbook-data-structures-for-real-life-wins
+  note: I love blog posts like this one that take common industrial software engineering
+    challenges and employ fundamental CS concepts to solve them.
+- date: '2020-11-01'
+  type: article
+  title: When is it time to quit my 9-5?
+  url: https://letterstoanewdeveloper.com/2020/10/26/when-is-it-time-to-quit-my-9-5/
+  note: Interesting perpsective on the heuristics and hard metrics used by Pariss
+    Athena (the founder of Black Tech Pipeline (BTP)) to calculate the best time for
+    her to quit her day job and focus on her passion project.
+- date: '2020-11-08'
+  type: article
+  title: Supply-Side Shocks Don't Cause Ample Increases in Nominal Income
+  url: https://www.nominalthoughts.com/2020/08/supply-side-shocks-dont-cause-amples.html?m=1
+  note: This was written a while ago, but I only found out about the author this week
+    (an economist named Jason Harrison), and I thought this was an interesting analysis
+    of why recessions tended to lead to "Great Inflations" due to the policies put
+    in place by the Fed, rather than recessions being a result of significant supply-side
+    shocks.  It's a nice contrarian take to classic macroeconomics and worth considering.
+- date: '2020-11-08'
+  type: article
+  title: What was fun?
+  url: https://www.vox.com/the-goods/21523704/fun-quarantine-home
+  note: I found this incredibly relatable; it talks about the foundational component
+    of "fun" and how the quarantine has denied us one of the critical factors, which
+    is spontaneity and the freedom to push ourselves outside of our comfort zone.  With
+    caution being espoused so liberally in these pandemic times, fun is clearly suffering.
+- date: '2020-11-08'
+  type: article
+  title: Kelsey Hightower
+  url: https://www.protocol.com/kelsey-hightower-google-cloud
+  note: Inspiring profile on one of the most inspiring guys in tech.  I'm not really
+    a Go or K8s user but I have big respect for Kelsey's work and work ethic.
+- date: '2020-11-08'
+  type: article
+  title: When Terrible Things Happen, our Numbers Go Up
+  url: https://digiday.com/media/when-terrible-things-happen-our-numbers-go-up-how-nyt-cooking-is-approaching-the-pandemic-politics-and-inclusion/
+  note: As the world shut down this spring, The New York Times dropped the paywall
+    to its What To Cook collection.  It was a sign of goodwill to the millions of
+    people stranded at home looking for a culinary project — or just some comfort
+    food — but it was also a timely ploy to lure more subscribers into NYT Cooking,
+    the paper’s standalone recipe storehouse and home kitchen guide.
+- date: '2020-11-08'
+  type: article
+  title: When your Manager Isn't Supporting you, Build a Voltron
+  url: https://larahogan.me/blog/manager-voltron/
+  note: Julia Evans tipped me off to this excellent read from Lara Hogan about how
+    to effectively drive your career even in a situation where your manager isn't
+    providing the support that you need.  I know a few of folks who have been in this
+    situation and I think anyone who's struggled with their relationship with their
+    boss would get something useful from this piece.
+- date: '2020-11-08'
+  type: article
+  title: Names are not Type Safety
+  url: https://lexi-lambda.github.io/blog/2020/11/01/names-are-not-type-safety/
+  note: Another excellent technical deep dive on accidental misuse of the `newtype`
+    keyword to attempt to provide type safety that only ends up providing an alias.  It's
+    long but excellent.
+- date: '2020-11-08'
+  type: article
+  title: 'Edsger Dijkstra: The Man Who Carried Computer Science on His Shoulders'
+  url: https://inference-review.com/article/the-man-who-carried-computer-science-on-his-shoulders
+  note: Grab a coffee for this one.  Probably 2.  Dijkstra is one of the pioneers
+    of computer science as a discipline and this is a detailed profile on his life.
+- date: '2020-11-08'
+  type: article
+  title: How to Seriously Read a Scientific Paper
+  url: https://www.sciencemag.org/careers/2016/03/how-seriously-read-scientific-paper
+  note: 'My graduate school friends likely know this stuff already, but as someone
+    who is trying to read more papers for fun, I got a lot out of this piece, which
+    profiles several academics providing tidbits of advice on how to read papers effectively.  A
+    big consistent theme: have an engaging task (note-taking, highlighting, writing)
+    to do alongside the paper read to encourage active engagement with the material
+    and prevent eye-glazing.'
+- date: '2020-11-08'
+  type: article
+  title: Grand Unified Theory of Software Architecture
+  url: https://danuker.go.ro/the-grand-unified-theory-of-software-architecture.html
+  note: A pragmatic approach to designing software.  Good content to consider when
+    code reviewing or writing your own code.
+- date: '2020-11-08'
+  type: article
+  title: Ugliest App
+  url: https://ugliest.app/
+  note: As someone with a lot of backend development experience who hasn't worked
+    as much on building a pretty frontend to match, this app platform speaks to my
+    soul.
+- date: '2020-11-15'
+  type: article
+  title: How I Start
+  url: https://howistart.org/
+  note: Often tutorials and books are overly generic, leaving it up to the reader
+    to wade through all the tools and styles available to a language on their own.
+    These articles are meant for a user who is comfortable with a language in its
+    REPL (if available) or building individual modules, but may not be comfortable
+    taking the step to producing an application or library that is ready to be consumed
+    by others or deployed to production.
+- date: '2020-11-15'
+  type: article
+  title: 'Haskell: The Bad Parts, part 2'
+  url: https://www.snoyman.com/blog/2020/11/haskell-bad-parts-2
+  note: Another excellent criticism of some of Haskell's warts from the prolific Snoyberg.  If
+    you're interested in critiquing programming language design choices, especially
+    for a language as carefully designed as Haskell, you'll likely enjoy this read.  Rust
+    fans probably will, too ;)
+- date: '2020-11-15'
+  type: article
+  title: Open-sourcing Haxl, a library for Haskell
+  url: https://engineering.fb.com/2014/06/10/web/open-sourcing-haxl-a-library-for-haskell/
+  note: Honestly, this was one of my favorite reads of the week because it's an thorough
+    and detailed writeup of how Facebook solved a technical problem in the perfect
+    way by using Haskell.  One my current gripes with Haskell blogs (I'm still pretty
+    new to learning which ones to read, so bear with me) is that many of them focus
+    on small, one-off problems and don't make a case for why Haskell is the best tool
+    for an enterprise use case.  This post does a great job for that, and I'd recommend
+    it to anyone who's curious about why Haskell matters for enterprise software development.
+- date: '2020-11-15'
+  type: article
+  title: Distributed Systems Learning Diary
+  url: https://timilearning.com/
+  note: A great example of learning in public by a guy named Timil in London.  I'm
+    currently working through his notes (and the source material) from the [Spark
+    Course](https://timilearning.com/posts/mit-6.824/lecture-15-spark/).
+- date: '2020-11-15'
+  type: article
+  title: Average UX Improvements Are Shrinking Over Time
+  url: https://www.nngroup.com/articles/ux-gains-shrinking/
+  note: this is good actually; the smaller improvements are indicating that our views
+    on what constitutes "good design" are starting to converge, which means that there's
+    less instability in how we approach UX design.
+- date: '2020-11-15'
+  type: article
+  title: How to Make the Kotlin Compiler Smarter
+  url: https://deniskrr.medium.com/how-to-make-the-compiler-smarter-b37f414875ac
+  note: The Kotlin compiler is smart, but sometimes you understand your code better
+    than the compiler.  With the use of Kotlin Contracts (a new compiler feature),
+    you can transfer your knowledge to the compiler by specifying the effect that
+    the invocation of a function produces.
+- date: '2020-11-15'
+  type: article
+  title: 'Troy Hunt: Hacking Grindr Accounts with Copy and Paste'
+  url: https://www.troyhunt.com/hacking-grindr-accounts-with-copy-and-paste/
+  note: Troy Hunt's exploit write-ups are always interesting and this one was a particularly
+    egregious bug.
+- date: '2020-11-15'
+  type: article
+  title: Virtual Consensus in Delos
+  url: https://www.usenix.org/conference/osdi20/presentation/balakrishnan
+  note: Again, another great post from Facebook engineering when they were solving
+    problems that no one else was worrying about.  Back in 2017 the engineering team
+    at Facebook had a problem. They needed a table store to power core control plane
+    services, which meant strong guarantees on durability, consistency, and availability.
+    They also needed it fast – the goal was to be in production within 6 to 9 months.
+    While ultimately this new system should be able to take advantage of the latest
+    advances in consensus for improved performance, that’s not realistic given a 6-9
+    month in-production target.  This paper describes what Facebook did to solve this
+    problem.
+- date: '2020-11-15'
+  type: article
+  title: Wasp
+  url: https://wasp-lang.dev/
+  note: Another cool application of Haskell that, while not as battle-tested by Mt.
+    Production as the Facebook applications are, still does a great job of showing
+    an area where Haskell is an exemplary product fit.  TL;DR, Haskell is a world-class
+    language for writing DSLs.
+- date: '2020-11-15'
+  type: article
+  title: Creating a Haskell development environment with LSP on NixOS – Jussi Kuokkanen’s
+    Computing Blog
+  url: https://jkuokkanen109157944.wordpress.com/2020/11/10/creating-a-haskell-development-environment-with-lsp-on-nixos/
+  note: Standard read on how to set up a Haskell dev environment.  I've been reading
+    a lot of these lately as I've been trying to find the best way to run Haskell
+    on my machine and the approach outlined by this author works well for me so far.
+- date: '2020-11-22'
+  type: article
+  title: DoorDash and Societal Arbitrage
+  url: https://themargins.substack.com/p/doordash-and-societal-arbitrage
+  note: This is the best thing I read last week.  Absolutely captivating content about
+    (among other things) how well-moneyed startups are weaponizing government programs
+    that were intended to help small businesses.
+- date: '2020-11-22'
+  type: tweet
+  title: This tweet by patio11 about execution vs innovation
+  url: https://twitter.com/patio11/status/1328965644528783362?s=20
+  note: Specifically, I liked the question of "how would we reliably and safely get
+    every American $10 every week?"
+- date: '2020-11-22'
+  type: article
+  title: "'It's the screams of the damned!' The eerie AI world of deepfake music"
+  url: https://www.theguardian.com/music/2020/nov/09/deepfake-pop-music-artificial-intelligence-ai-frank-sinatra
+  note: I think a lot about the effect of ML on music generation and this article
+    does a decent job summarizing the current state of AI music generation.  Worth
+    checking out Google's [Magenta Project](https://magenta.tensorflow.org/), too.
+- date: '2020-11-22'
+  type: article
+  title: The Gods on HackerNews
+  url: https://www.riknieu.com/the-gods-on-hackernews/
+  note: and [Holy heck this is hard](https://www.indiehackers.com/post/holy-heck-this-is-hard-8ebe864174).  Hackernews
+    is mostly a great thing to read if you're interested in cool content but the comment
+    sections can be a a total cesspool and the first link is a tongue-in-cheek commentary
+    on how any time someone does something cool and shares it with Hackernews then
+    there's always a bunch of folks who think it's _super edgy_ to just dunk on it.  And
+    the second link is a reflection on how hard making and scaling a product independently
+    is really difficult.
+- date: '2020-11-22'
+  type: article
+  title: I sold Baremetrics
+  url: https://baremetrics.com/blog/i-sold-baremetrics
+  note: In the same spirit of the previous link, this one is a story of someone who
+    did successfully accomplish the very difficult challenge of building, scaling,
+    and selling his technology business.
+- date: '2020-11-22'
+  type: article
+  title: Simple Explanations without Sounding Condescending
+  url: https://jvns.ca/blog/2020/11/15/simple-explanations-without-sounding-condescending/
+  note: Another excellent read from Julia Evans about how to explain things well.  Some
+    of her techniques include (1) write true explanations (as compared to ELI5-esque
+    ones) (2) only use visuals if the visuals are easy to understand (3) tell a relevant
+    story and (4) have a specific audience (explanations are not one-size fits all).
+- date: '2020-11-22'
+  type: article
+  title: Managing Multiple Java, SBT, and Scala Versions with SDKMAN
+  url: https://mungingdata.com/java/sdkman-multiple-versions-java-sbt-scala/
+  note: One of the trickiest challenges of getting started effectively with Scala
+    can be managing the various different dependency versions.  While I prefer [coursier](https://github.com/coursier/coursier)
+    for dependency management myself, many of my coworkers like SDKMAN and this post
+    provides a thorough overview of using it.
+- date: '2020-11-22'
+  type: article
+  title: 'Neil Mitchell''s Blog (Haskell etc): Turing Incomplete Languages'
+  url: https://neilmitchell.blogspot.com/2020/11/turing-incomplete-languages.html
+  note: Long and technical read about how some languages ban recursion to ensure programs
+    "terminate". While that's technically true, its usually irrelevant.
+- date: '2020-11-22'
+  type: article
+  title: How to get root on Ubuntu 20.04 by pretending nobody’s /home - GitHub Security
+    Lab
+  url: https://securitylab.github.com/research/Ubuntu-gdm3-accountsservice-LPE
+  note: I love reading about exploits and this one was a thorough writeup (complete
+    with a video) and an engaging read.
+- date: '2020-11-22'
+  type: article
+  title: Postgres Observability
+  url: https://pgstats.dev/
+  note: PostGRES is probably my favorite open-source technology and it's amazing to
+    see how many good resources there are to learn about it.  This link visualizes
+    every part of the PostGRES stack and explains what it does.
+- date: '2020-11-29'
+  type: article
+  title: Playing on Hard Mode
+  url: https://stratechery.com/2020/playing-on-hard-mode/
+  note: World-class piece from Ben Thompson on why it's no longer easy to make the
+    new Facebook or Google.
+- date: '2020-11-29'
+  type: article
+  title: Big Tech Sees Like a State
+  url: https://diff.substack.com/p/big-tech-sees-like-a-state
+  note: Fascinating read on the overlap between state-run economic engines and the
+    exploitative policies of certain big tech companies that mirror them.
+- date: '2020-11-29'
+  type: article
+  title: Being Glue
+  url: https://noidea.dog/glue
+  note: Long read on how being good at your job can often lead to not being recognized
+    as such because many workplaces measure and reward the wrong things.
+- date: '2020-11-29'
+  type: article
+  title: Shai Mendel's Dev Blog
+  url: https://shaimendel.dev/docs/2020-11-02-turn-the-senior-around
+  note: Interesting perspective on reframing the role of a senior engineer to focus
+    more on mentorship and guidance and less on actually churning out code and owning
+    features.  In my experience, this is the best way that senior engineers can maximize
+    their value.
+- date: '2020-11-29'
+  type: article
+  title: Six months of Tiny Projects
+  url: https://tinyprojects.dev/posts/six_months_of_tiny_projects
+  note: The author transparently lays out his work, projects, and ROI for a bunch
+    of side hustles that he'd done over the last 6 months.  Engaging read.
+- date: '2020-11-29'
+  type: article
+  title: Building the most inaccessible site possible with a perfect Lighthouse score
+  url: https://www.matuzo.at/blog/building-the-most-inaccessible-site-possible-with-a-perfect-lighthouse-score/
+  note: I used to use lighthouse for my site, and while it does some things well,
+    I've since upgraded to a new tool -- the reasons in this article aren't the reason
+    why, but they're funny.
+- date: '2020-11-29'
+  type: article
+  title: 'PostgresqlCO.NF: PostgreSQL configuration for humans'
+  url: https://postgresqlco.nf/en/doc/param/
+  note: and [psql command line tutorial and cheat sheet](https://tomcam.github.io/postgres/).  More
+    useful PostGRES tools.  My workplace is a big PostGRES shop and I'm sharing the
+    things I've been reading.
+- date: '2020-11-29'
+  type: article
+  title: The True Size Of ..
+  url: https://thetruesize.com/
+  note: This is cute!
+- date: '2020-11-29'
+  type: article
+  title: Managing Database Migrations in Scala
+  url: https://alexn.org/blog/2020/11/15/managing-database-migrations-scala.html
+  note: DB migrations are a common operation when database changes are needed to accommodate,
+    say, 3rd-Party API changes.  This is a useful guide on how to do these DB migrations
+    in a type-safe way.
+- date: '2020-11-29'
+  type: article
+  title: 'Elle: inferring isolation anomalies from experimental observations'
+  url: https://people.ucsc.edu/~palvaro/elle_vldb21.pdf
+  note: Is there anything more terrifying, and at the same time more useful, to a
+    database vendor than Kyle Kingsbury’s Jepsen? As the abstract of this paper wryly
+    puts it, “experience shows that many databases do not provide the isolation guarantees
+    they claim.” Jepsen captures execution histories, and then examines them for evidence
+    of isolation anomalies.
+- date: '2020-11-29'
+  type: article
+  title: Parse, don’t type-check
+  url: https://neilmadden.blog/2020/11/25/parse-dont-type-check/
+  note: Fantastic follow-up to [this piece](https://lexi-lambda.github.io/blog/2020/11/01/names-are-not-type-safety/)
+    by another excellent Haskell engineer.
+- date: '2020-12-06'
+  type: article
+  title: Welcome to the Cloud Zoo
+  url: https://pudding.cool/2020/11/cloud-zoo/
+  note: "[Photo quiz: This is an experiment about how we view history](https://pudding.cool/2020/10/photo-history/),
+    [Why are K-pop groups so big?](https://pudding.cool/2020/10/kpop/)    Big batch
+    of projects from one of my favorite online newsletters: The Pudding.  My mini-descriptions
+    will not do any of the links justice -- check them out!"
+- date: '2020-12-06'
+  type: article
+  title: 'Lorde: The Blackbird Spyplane Interview - Blackbird Spyplane'
+  url: https://www.blackbirdspyplane.com/p/lorde-the-blackbird-spyplane-interview
+  note: Jonah Weiner writes this hilarious newsletter on fashion, culture, and general
+    media-elite navel-gazing, and I loved this week's interview with Lorde.  I'm a
+    big Lorde stan and it's not surprising that this newsletter's interview with her
+    was so cool.
+- date: '2020-12-06'
+  type: article
+  title: Inside the New York Public Library's Last, Secret Apartments - Atlas Obscura
+  url: https://www.atlasobscura.com/articles/inside-the-new-york-public-librarys-last-secret-apartments
+  note: 'My favorite paragraph: "When these libraries were built, about a century
+    ago, they needed people to take care of them. Andrew Carnegie had given New York
+    $5.2 million, worth well over $100 million today, to create a city-wide system
+    of library branches, and these buildings, the Carnegie libraries, were heated
+    by coal. Each had a custodian, who was tasked with keeping those fires burning
+    and who lived in the library, often with his family. “The family mantra was: Don’t
+    let that furnace go out,” one woman who grew up in a library told the New York
+    Times."  New York has so much cool history and this piece does a great job of
+    conjuring up the historical context around a cool New York attribute.'
+- date: '2020-12-06'
+  type: article
+  title: This Japanese Shop Is 1,020 Years Old. It Knows a Bit About Surviving Crises.
+    - The New York Times
+  url: https://www.nytimes.com/2020/12/02/business/japan-old-companies.html
+  note: Slow and stable works for a business if everyone is on the same page.
+- date: '2020-12-06'
+  type: article
+  title: Career Chats with Swyx and Randall (Staff Eng Podcast by Lethain)
+  url: https://share.transistor.fm/s/d499230a
+  note: What happens after you go past Senior? Will Larson, CTO of Calm, has been
+    interviewing Staff-plus engineers across the industry for his new book, Staff
+    Engineering. This is his first full-length interview podcast episode!
+- date: '2020-12-06'
+  type: article
+  title: 2020 Haskell survey analysis
+  url: https://www.ariis.it/static/articles/2020-haskell-survey-analysis/page.html
+  note: Some findings from the 2020 State of Haskell survey that extracts some additional
+    insight from the data by clustering the respondents into various categories based
+    on their Haskell usage and experience and analyzing the responses of those clusters.
+- date: '2020-12-06'
+  type: article
+  title: thought leaders and chicken sexers
+  url: https://ideolalia.com/essays/thought-leaders-and-chicken-sexers.html
+  note: Well-researched and thorough essay taking aim at some of Paul Graham's rhetoric
+    and his history not following through on language design concepts.  Spawned some
+    [Twitter])(https://twitter.com/ztellman/status/1336046099207864320) and [HackerNews](https://news.ycombinator.com/item?id=25325716)
+    drama, as expected.
+- date: '2020-12-06'
+  type: article
+  title: In defense of blub studies
+  url: https://www.benkuhn.net/blub/
+  note: 'My favorite line: "In short, if you’re in search of generalizable knowledge
+    that compounds exponentially over time, then blub studies looks like the crap
+    you have to wade through to get to the good stuff. So it’s easy to see why people
+    give up on understanding all the blub they’re surrounded by, except what they
+    need to get the job done.  But for me, the opposite attitude has been more productive.
+    Computers can be understood—even if it’s hard and takes a while. Blub studies
+    is more generalizable than it seems, and has its own way of compounding over time,
+    too. That makes it a lot more useful than you’d expect."'
+- date: '2020-12-06'
+  type: article
+  title: Language Servers are the New Frameworks
+  url: https://dev.to/dx/language-servers-are-the-new-frameworks-1lbm
+  note: 'Cool read on the value of language servers in improving overall developer
+    experience. My favorite line: "Linting, typing, always-running-compilation and
+    other forms of write-time checks and optimizations are not new. In fact, when
+    dev teams write unit tests and lint rules, they are essentially creating their
+    own bespoke language server for their own app. What''s new is that giving realtime
+    feedback is now a responsibility shared by frameworks. This standardization increases
+    productivity both when starting a new project and moving between projects."'
+- date: '2020-12-13'
+  type: article
+  title: About Reading 100 Books
+  url: https://durmonski.com/private/reading-100-books/
+  note: 'I''ve always read for pleasure.  Ever since I could read, it''s something
+    I''ve always enjoyed doing, and I end up reading between 20-30 books a year just
+    because I can''t help myself.  This article makes an interesting case for the
+    value prop of reading, which I found interesting, especially since I don''t really
+    care about it.  I read because I''m curious, because I enjoy the feeling of losing
+    myself in a book, and because I honestly can''t help myself.  But, if you''re
+    the type of person who chooses their hobbies based on how these hobbies will benefit
+    them, I''m all for encouraging folks to read more.  To wit, here''s my favorite
+    except from this piece: "reading is not about getting outside gains. It’s primarily
+    about taming your inner demons and finding comfort in your own skin. Once you
+    start accepting yourself the way you are, eventually, positive consequences will
+    follow."'
+- date: '2020-12-13'
+  type: article
+  title: DoorDash and AirBnb IPOs
+  url: https://thegeneralist.substack.com/p/doordash-the-value-of-speed
+  note: ") got me feeling this kind of way: [Exasperated Exuberance](https://themargins.substack.com/p/exasperated-exuberance)"
+- date: '2020-12-13'
+  type: article
+  title: The Year on TikTok
+  url: https://newsroom.tiktok.com/en-us/the-year-on-tiktok-top-100
+  note: I don't use TikTok because I waste enough time online as it is but I after
+    watching some of these videos I get how people can spend so much time on it.  Creeps
+    me out.
+- date: '2020-12-13'
+  type: article
+  title: How Iowa Mishandled the Coronavirus Pandemic
+  url: https://www.theatlantic.com/politics/archive/2020/12/how-iowa-mishandled-coronavirus-pandemic/617252/
+  note: I'm lucky to have the privilege to be as insulated from Covid as anyone else
+    in this country, and so each week I try to read something to keep the direness
+    of the pandemic as close to the front of my mind as possible.
+- date: '2020-12-13'
+  type: article
+  title: An ex-Googler's guide to dev tools
+  url: https://about.sourcegraph.com/blog/ex-googler-guide-dev-tools/
+  note: I love Sourcegraph, have used it at previous companies, and deeply resonate
+    with the problem they're trying to solve.
+- date: '2020-12-13'
+  type: article
+  title: Performance · microsoft/TypeScript Wiki · GitHub
+  url: https://github.com/microsoft/TypeScript/wiki/Performance
+  note: Performance, like most things in software engineering, is a tradeoff, but
+    for folks who are interested in considering potential opportunities for speeding
+    up TypeScript apps, this wiki outlines many concrete steps that developers can
+    follow to do that.
+- date: '2020-12-13'
+  type: article
+  title: Bias in word embeddings
+  url: https://dl.acm.org/doi/10.1145/3351095.3372843
+  note: This paper examines bias in word embeddings, and how that bias carries forward
+    into models that are trained using them. There are definitely some dangers to
+    be aware of here, but also some cause for hope as we also see that bias can be
+    detected, measured, and mitigated.
+- date: '2020-12-13'
+  type: article
+  title: Optimal prediction of the number of unseen species
+  url: https://www.pnas.org/content/113/47/13283
+  note: 'This paper attempts to answer the excellent question: "just how well do we
+    understand the diversity of species in our biome?"'
+- date: '2020-12-13'
+  type: article
+  title: 'Haskell Documentation with Haddock: Wishes''n''Tips'
+  url: https://kowainik.github.io/posts/haddock-tips
+  note: Haskell has a reputation both internally and externally for having-poorly
+    documented libraries (it's the [2nd-most cited reason](https://taylor.fausak.me/2020/11/22/haskell-survey-results/)
+    for folks' unwillingness to embrace the language).  And I kinda get it; I personally
+    think Haskell code does _read_ quite clearly once you've spent some time grokking
+    functional programming.  However, I also think that documentation and "here's
+    what this code literally _does_" are two different things, and Haskell could certainly
+    improve in the "documentation", i.e. "here's why we chose to implement the code
+    this way, and what we imagined the use case that method/library is solving" category.  That's
+    where this blog post shines; Haskell has a excellent documentation toolchain,
+    and I think that when it's done well (Mercury's codebase, for example, is one
+    of the better-commented ones that I've seen), Haskell can have as good of documentation
+    as any language -- frankly, I think it can be one of the best, since the language
+    itself does such a good job of explaining the "how" that the comments need only
+    focus on the "why".
+- date: '2020-12-13'
+  type: article
+  title: How to Run a Ponzi Scheme for Tech People
+  url: https://callmenish.com/how-to-run-a-tech-ponzi-scheme/
+  note: This post is cuttingly sarcastic and calls out some folks that I know personally
+    in the tech writing community, but I think it's more of an indictment of the people
+    who buy these courses than the folks who make them.  Really, I think it's mostly
+    trying to say is that the author is frustrated by all the folks in tech who are
+    taking advantage of less-motivated but well-wheeled technologists who are desperate
+    for any edge on finding fulfillment and satisfaction that doesn't involve working
+    hard or taking risks.  Can't blame him.
+- date: '2020-12-13'
+  type: article
+  title: Transparent Octopus Caught by Blackwater Photographer Interview
+  url: https://mymodernmet.com/wu-yung-sen-blackwater-photography/
+  note: This is an absolutely mind-boggling bit of photography, and I love how the
+    photographer makes a point to talk about how the majority of these wild, transparent
+    creatures that live deep down are mostly larval forms of adult animals that may
+    look much more "normal" to our eyes.  Larval forms of terrestrial animals are
+    [super](https://www.nparks.gov.sg/nparksbuzz/issue-19-vol-4-2013/conservation/the-secret-life-of-dragonfly-larvae)
+    [wild](https://nature.mdc.mo.gov/discover-nature/field-guide/antlion-larvae-doodlebug-larvae),
+    and it's cool to see similar bizarre appearances from aquatic larvae.
+- date: '2020-12-20'
+  type: article
+  title: We read the paper that forced Timnit Gebru out of Google. Here’s what it
+    says
+  url: https://www.technologyreview.com/2020/12/04/1013294/google-ai-ethics-research-paper-forced-out-timnit-gebru
+  note: I don't have enough data to make a comprehensive opinion on the Timnit Gebru
+    situation, but from what I've seen so far it I'm definitely not siding with Google,
+    especially not after reading the pathetic "apology" that stank of gaslighting.  However,
+    the paper that Timnit worked on is very interesting, since the main thesis is
+    that much of our ML research is pointed at the _wrong problems_.  It's worth checking
+    it out in detail.
+- date: '2020-12-20'
+  type: article
+  title: Small tech
+  url: https://scattered-thoughts.net/writing/small-tech/
+  note: Tech companies that are useful without being bloated and overwrought.  Aspirational.
+- date: '2020-12-20'
+  type: article
+  title: '2020 In Photos: A Year Like No Other'
+  url: https://www.nytimes.com/interactive/2020/world/year-in-pictures.html
+  note: I think this year is a sign of wild years to come, but until we have data
+    for that, here's a picture history of the craziest year of my lifetime.
+- date: '2020-12-20'
+  type: article
+  title: Blob Opera
+  url: https://artsandculture.google.com/experiment/blob-opera/AAHWrq360NcGbw
+  note: Any project where [Jacob Collier](https://twitter.com/googlearts/status/1339948535312130051)
+    is involved is a good project IMO.  But seriously this is an incredible bit of
+    tech.  I played around with it for way too long.
+- date: '2020-12-20'
+  type: article
+  title: Texas Photographers have seen some shit
+  url: https://www.texasmonthly.com/being-texan/texas-wedding-photographers-have-seen-some/
+  note: This piece got me so mad.
+- date: '2020-12-20'
+  type: article
+  title: Defund the Crime Beat
+  url: https://www.niemanlab.org/2020/12/defund-the-crime-beat/
+  note: Crime coverage is terrible -- it’s racist, classist, fear-based clickbait
+    masking as journalism. It creates lasting harm for the communities that newsrooms
+    are supposed to serve. And because it so rarely meets the public’s needs, it’s
+    almost never newsworthy.  If we weren't so addicted to gory details as a population,
+    we'd have no need for it.  We should get rid of it.
+- date: '2020-12-20'
+  type: article
+  title: 'Haskell: The Bad Parts, part 3'
+  url: https://www.snoyman.com/blog/2020/12/haskell-bad-parts-3
+  note: 'I love Snoyberg''s Haskell posts; his deep knowledge and passion for improving
+    the language come through in every post, and they''re full of detail and insights.  One
+    of the bad parts he references in this post is pattern matching, which he has
+    a follow-up post for here: [Pattern matching](https://www.fpcomplete.com/blog/pattern-matching/).'
+- date: '2020-12-20'
+  type: article
+  title: 'Izuna: Show Haskell type annotations when doing code review on Github'
+  url: https://github.com/matsumonkie/izuna
+  note: Haskell has type inference, which is a useful feature when coding but sometimes
+    makes it more complicated when code reviewing to see which types are being used
+    if you're reviewing a part of the code that doesn't directly reference.  This
+    tool basically does the same thing as most IDEs do, only in the browser.  Super
+    useful!
+- date: '2020-12-20'
+  type: article
+  title: 'Themis Contract: A command line-based parameterized contracting tool'
+  url: https://github.com/informalsystems/themis-contract
+  note: 'Contract management software tools are becoming more and more mature, and
+    this tool is following that trend: it''s a CLI that lets you generate arbitrarily
+    complex contracts with minimal inputs needed!'
+- date: '2020-12-20'
+  type: article
+  title: 2020 in review
+  url: https://lethain.com/2020-in-review/
+  note: Nathan Larson is an excellent technical writer and someone who I've been fortunate
+    enough to work with on some of my technical pieces in the latter half of this
+    year.  His year in review is particular interesting because it's so metrics-driven;
+    I'd encourage any data junkie to check it out :)
+- date: '2020-12-20'
+  type: article
+  title: 'Writing a book: is it worth it?'
+  url: https://martin.kleppmann.com/2020/09/29/is-book-writing-worth-it.html
+  note: 'h/t @lethain for recommending this piece: it''s a well-written deep dive
+    into the meta work that goes into writing a technical book.  In Martin''s case,
+    his book is wildly successful, so it''s an inspirational (if aspirational) read.'
+- date: '2020-12-20'
+  type: article
+  title: Mimicry vs Reflexivity
+  url: https://www.swyx.io/mimicry-reflexivity/
+  note: 'got me thinking about [Veblen goods](https://en.wikipedia.org/wiki/Veblen_good)
+    and [Giffen goods](https://en.wikipedia.org/wiki/Giffen_good): to what extent
+    do we overvalue surface-level things because we''re trying to recreate the intrinsic
+    value of the thing that we''re imitating?'
+- date: '2020-12-20'
+  type: article
+  title: Super-Intelligent Humans Are Coming
+  url: http://nautil.us/issue/18/genius/super_intelligent-humans-are-coming
+  note: I also found this piece on Hystoria -- I think the overall conclusion reaches
+    a bit, but I did appreciate the data-driven approach to attempting to quantify
+    intelligence across multiple axes.
+- date: '2020-12-20'
+  type: article
+  title: 'Out There: On Not Finishing'
+  url: https://longreads.com/2020/09/08/out-there-on-not-finishing/
+  note: Resonant and beautiful.
+- date: '2021'
+  type: book
+  title: 1Q84
+  creator: Haruki Murakami
+- date: '2021'
+  type: book
+  title: Killing Commendatore
+  creator: Haruki Murakami
+- date: '2021'
+  type: book
+  title: In the Dream House
+  creator: Carmen Maria Machado
+- date: '2021'
+  type: book
+  title: Death's End
+  creator: Cixin Liu
+- date: '2021'
+  type: book
+  title: The Fifth Season
+  creator: N.K. Jemisin
+- date: '2021'
+  type: book
+  title: The Psychology of Money
+  creator: Morgan Housel
+- date: '2021'
+  type: book
+  title: Exhalation
+  creator: Ted Chiang
+- date: '2021'
+  type: book
+  title: The Obelisk Gate
+  creator: N.K. Jemisin
+- date: '2021'
+  type: book
+  title: The Stone Sky
+  creator: N.K. Jemisin
+- date: '2021'
+  type: book
+  title: Haskell Programming from First Principles
+  creator: Chris Allen and Julie Moronuki
+- date: '2021'
+  type: book
+  title: Vesper Flights
+  creator: Helen MacDonald
+- date: '2021'
+  type: book
+  title: Braiding Sweetgrass
+  creator: Robin Wall Kimmerer
+- date: '2021'
+  type: book
+  title: The Ninth House
+  creator: Leigh Bardugo
+- date: '2021'
+  type: book
+  title: Salat
+  creator: Dujie Tahat
+- date: '2021'
+  type: book
+  title: Amazon Unbound
+  creator: Brad Stone
+- date: '2021'
+  type: book
+  title: Abolish Silicon Valley
+  creator: Wendy Liu
+- date: '2021'
+  type: book
+  title: Version Zero
+  creator: David Yoon
+- date: '2021'
+  type: book
+  title: Zero to One
+  creator: Peter Thiel
+- date: '2021'
+  type: book
+  title: Zero In
+  creator: Dean Koontz
+- date: '2021'
+  type: book
+  title: Minor Problems
+  creator: Cathy Park Hong
+- date: '2021'
+  type: book
+  title: Here I Am O My God
+  creator: Dujie Tahat
+- date: '2021'
+  type: book
+  title: I'm Thinking of Ending Things
+  creator: Iain Reid
+- date: '2021'
+  type: book
+  title: Fingersmith
+  creator: Sarah Waters
+- date: '2021'
+  type: book
+  title: Homeland
+  creator: Corey Doctorow
+- date: '2021'
+  type: book
+  title: Attack Surface
+  creator: Corey Doctorow
+- date: '2021'
+  type: book
+  title: Blood Meridian
+  creator: Cormac McCarthy
+- date: '2021'
+  type: book
+  title: 'Draft No. 4: On the Writing Process'
+  creator: John McPhee
+- date: '2021'
+  type: book
+  title: Capitalism without Capital
+  creator: Jonathan Haskel and Stian Westlake
+- date: '2021'
+  type: book
+  title: The Manager's Path
+  creator: Camille Fournier
+- date: '2021'
+  type: book
+  title: The Revolt of the Public
+  creator: Martin Gurri
+- date: '2021'
+  type: book
+  title: Working in Public
+  creator: Nadia Eghbal
+- date: '2021'
+  type: book
+  title: Fossil Capital
+  creator: Andreas Malm
+- date: '2021'
+  type: book
+  title: The Ministry for the Future
+  creator: Kim Stanley Robinson
+- date: '2021'
+  type: book
+  title: Bless Me, Ultima
+  creator: Rudolfo Anaya
+- date: '2021'
+  type: book
+  title: Slade House
+  creator: David Mitchell
+- date: '2021'
+  type: book
+  title: Averno
+  creator: Louise Gluck
+- date: '2023'
+  type: movie
+  title: A Clockwork Orange
+  creator: Stanley Kubrick
+- date: '2023'
+  type: movie
+  title: French Dispatch
+  creator: Wes Anderson
+- date: '2023'
+  type: movie
+  title: C'mon C'mon!
+  creator: Michael Mills
+- date: '2023'
+  type: movie
+  title: The Royal Tenenbaums
+  creator: Wes Anderson
+- date: '2023'
+  type: movie
+  title: The Florida Project
+  creator: Sean Baker
+- date: '2023'
+  type: movie
+  title: The Life Aquatic with Steven Zissou
+  creator: Wes Anderson
+- date: '2023'
+  type: movie
+  title: The Power of the Dog
+  creator: Jane Campion
+- date: '2023'
+  type: movie
+  title: We Need to Talk About Cosby
+  creator: W Kamau Bell
+- date: '2023'
+  type: movie
+  title: Call Jane
+  creator: Phyllis Nagy
+- date: '2023'
+  type: movie
+  title: Babysitter
+  creator: Monia Chokri
+- date: '2023'
+  type: movie
+  title: Freedom Swimmer
+  creator: Olivia Martin-Mcguire
+- date: '2023'
+  type: movie
+  title: A Thousand Ways to Kiss the Ground
+  creator: Henna Taylor
+- date: '2023'
+  type: movie
+  title: Can't Beat This Place For Fun
+  creator: Dawn Kish
+- date: '2023'
+  type: movie
+  title: Learning to Drown
+  creator: Ben Knight
+- date: '2023'
+  type: movie
+  title: The Batman
+  creator: Matt Reeves
+- date: '2023'
+  type: movie
+  title: 3 Idiots
+  creator: Rajkumar Hirani
+- date: '2023'
+  type: movie
+  title: Another Round
+  creator: Thomas Vinterberg
+- date: '2023'
+  type: book
+  title: Play It As It Lays
+  creator: Joan Didion
+- date: '2023'
+  type: book
+  title: Jitterbug Perfume
+  creator: Tom Robbins
+- date: '2023'
+  type: book
+  title: 'Tenth of December: Stories'
+  creator: George Saunders
+- date: '2023'
+  type: book
+  title: Scout Mindset
+  creator: Julia Galef
+- date: '2023'
+  type: book
+  title: The White Album
+  creator: Joan Didion
+- date: '2023'
+  type: book
+  title: Slouching Towards Bethlehem
+  creator: Joan Didion
+- date: '2023'
+  type: book
+  title: The Brief Wondrous Life of Oscar Wao
+  creator: Junot Diaz
+- date: '2023'
+  type: book
+  title: This is How You Lose Her
+  creator: Junot Diaz
+- date: '2023'
+  type: book
+  title: Wait for Signs
+  creator: Craig Johnson
+- date: '2023'
+  type: book
+  title: Song of Achilles
+  creator: Madeline Miller
+- date: '2023'
+  type: book
+  title: Circe
+  creator: Madeline Miller
+- date: '2023'
+  type: book
+  title: The Memory Police
+  creator: Yoko Ogawa
+- date: '2023'
+  type: book
+  title: Too Like the Lightning
+  creator: Ada Palmer
+- date: '2024'
+  type: movie
+  title: Asteroid City
+  creator: Wes Anderson
+- date: '2024'
+  type: movie
+  title: Past Lives
+  creator: Celine Song
+- date: '2024'
+  type: movie
+  title: Poor Things
+  creator: Yorgos Lanthimos
+- date: '2024'
+  type: movie
+  title: The Holdovers
+  creator: Alexander Payne
+- date: '2024'
+  type: movie
+  title: Dune 2
+  creator: Denis Villeneuve
+- date: '2024'
+  type: book
+  title: Demon Copperhead
+  creator: Barbara Kingsolver
+- date: '2024'
+  type: book
+  title: Infinite Jest
+  creator: David Foster Wallace
+- date: '2024'
+  type: book
+  title: Babel
+  creator: R.F. Huang
+- date: '2024'
+  type: book
+  title: Hyperion
+  creator: David Simmons
+- date: '2024'
+  type: book
+  title: A Supposedly Fun Thing I'll Never Do Again
+  creator: David Foster Wallace
+- date: '2024'
+  type: book
+  title: The Fall of Hyperion
+  creator: David Simmons
+- date: '2024'
+  type: book
+  title: Red Team Blues
+  creator: Cory Doctorow
+- date: '2024'
+  type: book
+  title: Klara and the Sun
+  creator: Kazuo Ishiguro
+- date: '2025-05-16'
+  type: movie
+  title: I Saw the TV Glow
+  creator: Jane Schoenbrun
+  rating: 3.5
+  note: Banging soundtrack, lynchian as hell, pacing was sometimes a bit wonky but
+    it really picked up steam for the last half hour.
+- date: '2025-05-16'
+  type: movie
+  title: A Real Pain
+  creator: Jesse Eisenberg
+  rating: 4.0
+  note: |-
+    Kieran Culkin is goated at playing broken, brutally honest characters.
+    Enjoyed this more than I expected; it’s carried by the performance of the leads (especially Culkin), and I enjoyed the character development — plenty of depth and context, but also space for the viewer to fill in the blanks with their imagination.
+- date: '2025-05-17'
+  type: movie
+  title: Anora
+  creator: Sean Baker
+  rating: 4.5
+  note: Great plane movie
+- date: '2025-06-09'
+  type: movie
+  title: Friendship
+  creator: Andrew DeYoung
+  rating: 3.5
+  note: We never should’ve left Afghanistan
+- date: '2025-06-23'
+  type: movie
+  title: Palm Springs
+  creator: Max Barbakow
+  rating: 4.0
+  note: All those days and he never put his dick in a box
+- date: '2025-06-28'
+  type: movie
+  title: The Phoenician Scheme
+  creator: Wes Anderson
+  rating: 3.5
+  note: Man took a bullet for his friend and the dude still wouldn’t kick in 15% smh.
+- date: '2025-07-20'
+  type: movie
+  title: Joe Dirt
+  creator: Dennie Gordon
+  rating: 2.0
+  note: Feels like the kind of movie that gets better on the 100th rewatch because
+    you can quote the whole thing and spend the movie doing that instead of watching
+    it
+- date: '2025-08-07'
+  type: movie
+  title: Whiplash
+  creator: Damien Chazelle
+  rating: 4.0
+  note: Starbucks jazz is better than the shit Fletcher was playing at the club
+- date: '2025-08-07'
+  type: movie
+  title: Mickey 17
+  creator: Bong Joon-ho
+  rating: 3.5
+  note: I wonder if the director asked Pattinson to just do the opposite voice as
+    he did in Batman
+- date: '2025-08-09'
+  type: movie
+  title: Longlegs
+  creator: Osgood Perkins
+  rating: 4.0
+  note: Okay this probably isn’t actually as good as I ranked it but I fuckin loved
+    this. Sure it’s predictable and a bit of a played-out genre but man what a good
+    time
+- date: '2025-08-11'
+  type: movie
+  title: The Fall Guy
+  creator: David Leitch
+  rating: 2.5
+  note: I got this mixed up with Free Guy and spent most of the movie wondering when
+    Ryan Reynolds would show up
+- date: '2025-08-11'
+  type: movie
+  title: Rudy
+  creator: David Anspaugh
+  rating: 3.5
+  note: You can tell Rudy really leaned into his Notre dame degree because he got
+    convicted of securities fraud recently
+- date: '2025-08-21'
+  type: movie
+  title: Weapons
+  creator: Zach Cregger
+  rating: 3.5
+- date: '2025-10-27'
+  type: movie
+  title: Sinners
+  creator: Ryan Coogler
+  rating: 4.0
+  note: Probably the best ultra panavision movie I’ve ever seen
+- date: '2025-10-27'
+  type: movie
+  title: Blood Simple
+  creator: Joel Coen
+  rating: 4.0
+  note: I’ve heard that men are bad at communicating but this is ridiculous!
+- date: '2025-10-27'
+  type: movie
+  title: One Battle After Another
+  creator: Paul Thomas Anderson
+  rating: 4.5
+  note: I want to write something glib but honestly I just had a fucking blast. What
+    a treat. Shoutout to Jonny Greenwood for the Zelda dungeon-ass music during the
+    Latino Harriet Tubman scene
+- date: '2025-10-30'
+  type: movie
+  title: Bugonia
+  creator: Yorgos Lanthimos
+  rating: 3.5
+  note: No one told me this was gonna be a documentary!
+- date: '2025-12-29'
+  type: movie
+  title: Eddington
+  creator: Ari Aster
+  rating: 4.0
+  note: I would’ve loved to have seen Joe Cross in the CHOP
+- date: '2026-01-31'
+  type: tweet
+  title: Karpathy on the coding workflow shift
+  url: https://x.com/karpathy/status/2015883857489522876
+  note: '"Rapidly went from 80% manual coding to 80% agent coding." This is the signal.
+    When Karpathy says the workflow has flipped, pay attention.'
+- date: '2026-01-31'
+  type: article
+  title: Maybe you're not Actually Trying
+  url: https://usefulfictions.substack.com/p/maybe-youre-not-actually-trying
+  note: Cate Hall on effort and self-deception. One of those essays that sits with
+    you uncomfortably.
+- date: '2026-01-31'
+  type: article
+  title: One Year at PostHog
+  url: https://haacked.com/archive/2026/01/06/one-year-at-posthog/
+  note: Phil Haack's reflections on his first year. Phil's a coworker and friend,
+    and this piece is both honest and inspiring.
+- date: '2026-01-31'
+  type: article
+  title: Good and evil in Iran
+  url: https://samkriss.substack.com/p/good-and-evil-in-iran
+  note: Sam Kriss continues to be one of the most interesting writers working today.
+- date: '2026-01-31'
+  type: article
+  title: There's someone on the ice
+  url: https://samkriss.substack.com/p/theres-someone-on-the-ice
+  note: More Sam Kriss.
+- date: '2026-01-31'
+  type: article
+  title: Hating Stranger Things During the Death Rattle of Criticism
+  url: https://freddiedeboer.substack.com/p/hating-stranger-things-during-the
+  note: 'Freddie deBoer on the state of cultural criticism. Also his follow-up: [All
+    Kidding Aside, I Find the Creative Arc of Stranger Things to Be Quite Sad](https://freddiedeboer.substack.com/p/all-kidding-aside-i-find-the-creative).'
+- date: '2026-01-31'
+  type: article
+  title: Reading is hip again because nobody can read anymore
+  url: https://discordiareview.substack.com/p/reading-is-hip-again-because-nobody
+  note: The title says it all.
+- date: '2026-01-31'
+  type: article
+  title: Why are Americans Unhappy?
+  url: https://walkingtheworld.substack.com/p/why-are-americans-unhappy
+  note: Chris Arnade's Walks the World.
+- date: '2026-01-31'
+  type: article
+  title: I Wish People Were More Public
+  url: https://borretti.me/article/i-wish-people-were-more-public
+  note: Fernando Borretti making the case for putting yourself out there.
+- date: '2026-01-31'
+  type: article
+  title: How to live an intellectually rich life
+  url: https://utsavmamoria.substack.com/p/how-to-live-an-intellectually-rich
+  note: Utsav Mamoria on building a life of the mind.
+- date: '2026-01-31'
+  type: article
+  title: Defeating Nondeterminism in LLM Inference
+  url: https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/
+  note: Deep technical dive on making LLM inference deterministic across batches.
+    Essential reading if you're building on top of LLMs.
+- date: '2026-01-31'
+  type: article
+  title: A Social Filesystem
+  url: https://overreacted.io/a-social-filesystem/
+  note: Dan Abramov's latest, on social/collaborative filesystems. Always thinking
+    different.
+- date: '2026-01-31'
+  type: article
+  title: Welcome to Gas Town
+  url: https://steve-yegge.medium.com/welcome-to-gas-town-4f25ee16dd04
+  note: 'Steve Yegge on his multi-agent workspace manager. See also: [steveyegge/gastown](https://github.com/steveyegge/gastown)
+    and [steveyegge/beads](https://github.com/steveyegge/beads) ("memory upgrade for
+    your coding agent").'
+- date: '2026-01-31'
+  type: article
+  title: Software Design Ideas I Dislike
+  url: https://joodaloop.com/design-dislikes/
+  note: Contrarian takes on popular software design patterns.
+- date: '2026-01-31'
+  type: article
+  title: Tooltip Components Should Not Exist
+  url: https://tkdodo.eu/blog/tooltip-components-should-not-exist
+  note: TkDodo argues tooltips are a UI antipattern.
+- date: '2026-01-31'
+  type: article
+  title: 2025 LLM Year in Review
+  url: https://karpathy.bearblog.dev/year-in-review-2025/
+  note: Andrej Karpathy's year-end LLM review.
+- date: '2026-01-31'
+  type: article
+  title: Small Language Models are the Future of Agentic AI
+  url: https://arxiv.org/pdf/2506.02153
+  note: The case for small models in agent workflows.
+- date: '2026-01-31'
+  type: article
+  title: The Rise of Parasitic AI
+  url: https://www.lesswrong.com/posts/6ZnznCaTcbGYsCmqu/the-rise-of-parasitic-ai
+  note: On AI systems that feed off others' infrastructure.
+- date: '2026-01-31'
+  type: tweet
+  title: Mitchell Hashimoto on AI usage as an "idiot detector"
+  url: https://x.com/mitchellh/status/2011823007069847875
+  note: '"The way AI is driven is maybe the most effective tool at exposing idiots
+    I''ve ever seen."'
+- date: '2026-01-31'
+  type: article
+  title: Why Meta bought Limitless
+  url: https://sacra.com/research/why-meta-bought-limitless/
+  note: Deep analysis of Meta's acquisition of the AI wearable startup.
+- date: '2026-01-31'
+  type: article
+  title: GOAT's Path to Product-Market Fit
+  url: https://review.firstround.com/goats-path-to-product-market-fit/
+  note: How a fake sneaker problem sparked a $4B marketplace.
+- date: '2026-01-31'
+  type: article
+  title: The $30 Photo That Built a Billion-Dollar Brand
+  url: https://www.mousencheese.design/post/the-30-photo-that-built-a-billion-dollar-brand-how-airbnb-s-ux-pivot-changed-everything
+  note: Airbnb's UX pivot, told through one photo.
+- date: '2026-01-31'
+  type: article
+  title: At least 80 new tech unicorns were minted in 2025
+  url: https://techcrunch.com/2025/12/01/at-least-36-new-tech-unicorns-were-minted-in-2025-so-far/
+  note: TechCrunch's tally.
+- date: '2026-01-31'
+  type: article
+  title: Refactoring a product is tricky
+  url: https://www.jmduke.com/posts/refactoring-a-product-is-tricky.html
+  note: Justin Duke (Buttondown) on product refactoring.
+- date: '2026-01-31'
+  type: article
+  title: 'No management needed: anti-patterns in early-stage engineering teams'
+  url: https://www.ablg.io/blog/no-management-needed
+  note: On the "boring stack" of seed-stage management.
+- date: '2026-01-31'
+  type: article
+  title: Firefly research rabbit hole
+  url: https://elifesciences.org/articles/78908
+  note: My brother wrote this! It's about emergent periodicity in the collective synchronous
+    flashing of fireflies. Science is cool.
+- date: '2026-01-31'
+  type: article
+  title: Rubio Deletes Calibri as the State Department's Official Typeface
+  url: https://www.nytimes.com/2025/12/09/us/politics/rubio-state-department-font.html
+  note: The font wars have reached the federal government.
+- date: '2026-01-31'
+  type: article
+  title: 'Hands-On: Kollokium Projekt 02'
+  url: https://www.hodinkee.com/articles/kollokium-projekt-02-the-second-offering-from-the-swiss-platform-is-another-watch-that-defies-compar
+  note: Radical Swiss watch design from Hodinkee.
+- date: '2026-01-31'
+  type: article
+  title: Cloudflare Radar 2025 Year in Review
+  url: https://radar.cloudflare.com/year-in-review/2025#website-technologies
+  note: The internet by the numbers; reminds me that PostHog has a long way to go
+    to reach web-scale relevance.
+- date: '2026-01-31'
+  type: tweet
+  title: Jane Manchun Wong
+  url: https://x.com/wongmjane/status/2006211582380876139
+  note: '"My blog now uses Claude Opus 4.5 to compute the current year for the copyright
+    footer!" Peak 2026.'
+- date: '2026-02-15'
+  type: movie
+  title: Lost in Translation
+  creator: Sofia Coppola
+  rating: 4.0
+  note: |-
+    - masterclass in atmosphere
+    - i fundamentally don’t buy ennui as sexy or cool (and am incapable of it myself), but it’s fun to cosplay as people who do
+    - can adults have fun without flirting? is there more fun than flirting? bleak inquiry
+    - watched this right after a jet-lagged trip to London where i felt zero mystique, only fatigue. pretending is better
+    - one of my favorite depictions of work travel: not glamorous, just a quiet urge to disappear
+- date: '2026-04-27'
+  type: movie
+  title: Casino
+  creator: Martin Scorsese
+  rating: 3.5
+  note: |-
+    - the exact length of my flight to vegas so it was kind of perfect to set the vibes for that trip
+    - people are always like "oh joe pesci is so good" and like he is but he's the same guy in every movie
+    - pretty predictable plot but still pretty fun
+- date: '2026-04-27'
+  type: movie
+  title: Heat
+  creator: Michael Mann
+  rating: 5.0
+  note: this movie is fucking sick.
+- date: '2026-08-06'
+  type: movie
+  title: Burning
+  creator: Lee Chang-dong
+  rating: 4.0
+- date: '2026-08-06'
+  type: movie
+  title: Bodies Bodies Bodies
+  creator: Halina Reijn
+  rating: 3.0
+  note: Least dramatic rich kid party
+- date: '2026-08-06'
+  type: movie
+  title: TÁR
+  creator: Todd Field
+  rating: 4.0
+  note: 4 stars for the outfits and interior design alone
+- date: '2026-08-06'
+  type: movie
+  title: Saltburn
+  creator: Emerald Fennell
+  rating: 3.5
+  note: As slutty TikTok movies go I was actually pretty fond of this one. Can’t believe
+    The Talented Mr. Ripley (1999) ripped this off
+- date: '2026-08-06'
+  type: movie
+  title: Monkey Man
+  creator: Dev Patel
+  rating: 3.5
+  note: I like the part where he yelled “it’s Monkin’ time!” and then punched the
+    guy
+- date: '2026-08-06'
+  type: movie
+  title: Dìdi (弟弟)
+  creator: Sean Wang
+  rating: 4.0
+  note: I’ve never wanted to yell at a kid more in my life so I feel like they nailed
+    the experience of being a teenager
+- date: '2026-08-06'
+  type: movie
+  title: Bone Tomahawk
+  creator: S. Craig Zahler
+  rating: 4.0
+  note: This movie was a fuckin blast I don’t care if it’s derivative
+- date: '2026-08-06'
+  type: movie
+  title: Dragged Across Concrete
+  creator: S. Craig Zahler
+  rating: 3.5
+  note: |-
+    My favorite part of Zahler movies is that he cuts away from the gore because I’m squeamish.
+    Can’t wait to watch bone tomahawk next; I’ve heard it’s a campy western!
+- date: '2026-08-06'
+  type: movie
+  title: The Talented Mr. Ripley
+  creator: Anthony Minghella
+  rating: 4.5
+  note: They went into the future and ripped off Saltburn (2022) smh
+- date: '2026-08-06'
+  type: movie
+  title: 'Master and Commander: The Far Side of the World'
+  creator: Peter Weir
+  rating: 4.5
+  note: |-
+    I’m writing this review from the perspective of 13-year old me and my dad got me this movie for my birthday and we watched it together and he had to explain the lesser of two weevils joke and we had a wonderful evening together so yeah one of the best movies in my head canon.
+    I should watch it again though and see how it holds up.

--- a/_includes/stars.html
+++ b/_includes/stars.html
@@ -1,0 +1,1 @@
+{% if include.rating %}{% assign full = include.rating | floor %}{% for i in (1..full) %}★{% endfor %}{% assign half = include.rating | minus: full %}{% if half >= 0.5 %}<span class="star-half" aria-label="half star">☆<span aria-hidden="true">★</span></span>{% endif %}{% endif %}

--- a/media.html
+++ b/media.html
@@ -5,730 +5,328 @@ redirect_from:
     - /links.html
 ---
 
+<style>
+    .media-search {
+        width: 100%;
+        padding: 0.5rem 0.75rem;
+        margin: 1rem 0;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        color: var(--text);
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+    }
+    .media-search:focus {
+        outline: none;
+        border-color: var(--accent);
+    }
+    .media-year > summary,
+    .media-section > summary {
+        cursor: pointer;
+        list-style-position: outside;
+    }
+    .media-year > summary h2 {
+        display: inline-block;
+        margin: 0.75em 0 0.25em;
+    }
+    .media-section > summary h3 {
+        display: inline-block;
+        margin: 0.75em 0 0.25em;
+    }
+    .media-year > summary small,
+    .media-section > summary small {
+        color: var(--text-secondary);
+        margin-left: 0.5em;
+    }
+    .media-section {
+        margin-left: 1rem;
+    }
+    .media-date,
+    .media-stars {
+        white-space: nowrap;
+    }
+    .star-half {
+        position: relative;
+        display: inline-block;
+    }
+    .star-half > span {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 50%;
+        overflow: hidden;
+    }
+    .media-review .review-text {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+    .media-review.expanded .review-text {
+        display: block;
+        -webkit-line-clamp: unset;
+        overflow: visible;
+    }
+    .media-review.clampable {
+        cursor: pointer;
+    }
+    .review-more {
+        display: none;
+        color: var(--text-secondary);
+        font-size: 0.8em;
+        user-select: none;
+    }
+    .media-review.clampable .review-more {
+        display: inline;
+    }
+    .media-no-results {
+        color: var(--text-secondary);
+        display: none;
+        margin: 2rem 0;
+    }
+</style>
+
 <div class="page-content">
     <div class="main-content">
         <h1>Media</h1>
         <p>
-            Movies I've watched and books I've read, organized by year. Kept
-            up-to-date as often as I can remember to.
+            Everything I've read, watched, and otherwise engaged with —
+            articles, books, movies, and whatever else — organized by year.
+            Logged as I go; the highlights get written up in the
+            <a href="/digest.html">digest</a>.
         </p>
 
-        <h2>2025</h2>
-        <h3>Movies</h3>
-        <table class="styled-table">
-            <thead>
-                <tr>
-                    <th>Title</th>
-                    <th>Director</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>Eddington</td>
-                    <td>Ari Aster</td>
-                </tr>
-                <tr>
-                    <td>Bugonia</td>
-                    <td>Yorgos Lanthimos</td>
-                </tr>
-                <tr>
-                    <td>Sinners</td>
-                    <td>Ryan Coogler</td>
-                </tr>
-                <tr>
-                    <td>Blood Simple</td>
-                    <td>Joel Coen</td>
-                </tr>
-                <tr>
-                    <td>One Battle After Another</td>
-                    <td>Nick Cassavetes</td>
-                </tr>
-                <tr>
-                    <td>Weapons</td>
-                    <td>Zach Cregger</td>
-                </tr>
-                <tr>
-                    <td>The Fall Guy</td>
-                    <td>David Leitch</td>
-                </tr>
-                <tr>
-                    <td>Rudy</td>
-                    <td>David Anspaugh</td>
-                </tr>
-                <tr>
-                    <td>Longlegs</td>
-                    <td>Osgood Perkins</td>
-                </tr>
-                <tr>
-                    <td>Whiplash</td>
-                    <td>Damien Chazelle</td>
-                </tr>
-                <tr>
-                    <td>Mickey 17</td>
-                    <td>Bong Joon-ho</td>
-                </tr>
-                <tr>
-                    <td>Joe Dirt</td>
-                    <td>Dennie Gordon</td>
-                </tr>
-                <tr>
-                    <td>The Phoenician Scheme</td>
-                    <td>Wes Anderson</td>
-                </tr>
-                <tr>
-                    <td>Palm Springs</td>
-                    <td>Max Barbakow</td>
-                </tr>
-                <tr>
-                    <td>Friendship</td>
-                    <td>Andrew DeYoung</td>
-                </tr>
-                <tr>
-                    <td>Anora</td>
-                    <td>Sean Baker</td>
-                </tr>
-                <tr>
-                    <td>I Saw the TV Glow</td>
-                    <td>Jane Schoenbrun</td>
-                </tr>
-                <tr>
-                    <td>A Real Pain</td>
-                    <td>Jesse Eisenberg</td>
-                </tr>
-            </tbody>
-        </table>
+        <input
+            type="search"
+            class="media-search"
+            id="media-search"
+            placeholder="Search titles, creators, notes…"
+            aria-label="Search the media archive"
+        />
+        <p class="media-no-results" id="media-no-results">
+            Nothing matches that search.
+        </p>
 
-        <h2>2024</h2>
-        <h3>Movies</h3>
-        <table class="styled-table">
-            <thead>
-                <tr>
-                    <th>Title</th>
-                    <th>Director</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>Asteroid City</td>
-                    <td>Wes Anderson</td>
-                </tr>
-                <tr>
-                    <td>Past Lives</td>
-                    <td>Celine Song</td>
-                </tr>
-                <tr>
-                    <td>Poor Things</td>
-                    <td>Yorgos Lanthimos</td>
-                </tr>
-                <tr>
-                    <td>The Holdovers</td>
-                    <td>Alexander Payne</td>
-                </tr>
-                <tr>
-                    <td>Dune 2</td>
-                    <td>Denis Villeneuve</td>
-                </tr>
-            </tbody>
-        </table>
+        {% assign by_year = site.data.log | group_by_exp: "item", "item.date | slice: 0, 4" | sort: "name" | reverse %}
+        {% for year in by_year %}
+        <details class="media-year" {% if forloop.first %}open{% endif %}>
+            <summary>
+                <h2>{{ year.name }}</h2>
+                <small>{{ year.items | size }} entries</small>
+            </summary>
 
-        <h3>Books</h3>
-        <table class="styled-table">
-            <thead>
-                <tr>
-                    <th>Title</th>
-                    <th>Author</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>Demon Copperhead</td>
-                    <td>Barbara Kingsolver</td>
-                </tr>
-                <tr>
-                    <td>Infinite Jest</td>
-                    <td>David Foster Wallace</td>
-                </tr>
-                <tr>
-                    <td>Babel</td>
-                    <td>R.F. Huang</td>
-                </tr>
-                <tr>
-                    <td>Hyperion</td>
-                    <td>David Simmons</td>
-                </tr>
-                <tr>
-                    <td>A Supposedly Fun Thing I'll Never Do Again</td>
-                    <td>David Foster Wallace</td>
-                </tr>
-                <tr>
-                    <td>The Fall of Hyperion</td>
-                    <td>David Simmons</td>
-                </tr>
-                <tr>
-                    <td>Red Team Blues</td>
-                    <td>Cory Doctorow</td>
-                </tr>
-                <tr>
-                    <td>Klara and the Sun</td>
-                    <td>Kazuo Ishiguro</td>
-                </tr>
-            </tbody>
-        </table>
+            {% assign links = year.items | where_exp: "item", "item.url" %}
+            {% if links.size > 0 %}
+            <details class="media-section" open>
+                <summary>
+                    <h3>Links</h3>
+                    <small>{{ links.size }}</small>
+                </summary>
+                <table class="styled-table">
+                    <thead>
+                        <tr>
+                            <th>Title</th>
+                            <th>Date</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% assign sorted_links = links | sort: "date" | reverse %}
+                        {% for entry in sorted_links %}
+                        <tr>
+                            <td>
+                                <a href="{{ entry.url }}">{{ entry.title }}</a>
+                            </td>
+                            <td class="media-date">
+                                {% if entry.date.size > 4 %}{{ entry.date | date: "%b %-d" }}{% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </details>
+            {% endif %}
 
-        <h2>2023</h2>
-        <h3>Movies</h3>
-        <table class="styled-table">
-            <thead>
-                <tr>
-                    <th>Title</th>
-                    <th>Director</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>A Clockwork Orange</td>
-                    <td>Stanley Kubrick</td>
-                </tr>
-                <tr>
-                    <td>French Dispatch</td>
-                    <td>Wes Anderson</td>
-                </tr>
-                <tr>
-                    <td>C'mon C'mon!</td>
-                    <td>Michael Mills</td>
-                </tr>
-                <tr>
-                    <td>The Royal Tenenbaums</td>
-                    <td>Wes Anderson</td>
-                </tr>
-                <tr>
-                    <td>The Florida Project</td>
-                    <td>Sean Baker</td>
-                </tr>
-                <tr>
-                    <td>The Life Aquatic with Steven Zissou</td>
-                    <td>Wes Anderson</td>
-                </tr>
-                <tr>
-                    <td>The Power of the Dog</td>
-                    <td>Jane Campion</td>
-                </tr>
-                <tr>
-                    <td>We Need to Talk About Cosby</td>
-                    <td>W Kamau Bell</td>
-                </tr>
-                <tr>
-                    <td>Call Jane</td>
-                    <td>Phyllis Nagy</td>
-                </tr>
-                <tr>
-                    <td>Babysitter</td>
-                    <td>Monia Chokri</td>
-                </tr>
-                <tr>
-                    <td>Freedom Swimmer</td>
-                    <td>Olivia Martin-Mcguire</td>
-                </tr>
-                <tr>
-                    <td>A Thousand Ways to Kiss the Ground</td>
-                    <td>Henna Taylor</td>
-                </tr>
-                <tr>
-                    <td>Can't Beat This Place For Fun</td>
-                    <td>Dawn Kish</td>
-                </tr>
-                <tr>
-                    <td>Learning to Drown</td>
-                    <td>Ben Knight</td>
-                </tr>
-                <tr>
-                    <td>The Batman</td>
-                    <td>Matt Reeves</td>
-                </tr>
-                <tr>
-                    <td>3 Idiots</td>
-                    <td>Rajkumar Hirani</td>
-                </tr>
-                <tr>
-                    <td>Another Round</td>
-                    <td>Thomas Vinterberg</td>
-                </tr>
-            </tbody>
-        </table>
+            {% assign books = year.items | where: "type", "book" %}
+            {% if books.size > 0 %}
+            {% assign rated = books | where_exp: "item", "item.rating" %}
+            {% assign reviewed = books | where_exp: "item", "item.note" %}
+            <details class="media-section" open>
+                <summary>
+                    <h3>Books</h3>
+                    <small>{{ books.size }}</small>
+                </summary>
+                <table class="styled-table">
+                    <thead>
+                        <tr>
+                            <th>Title</th>
+                            <th>Author</th>
+                            {% if rated.size > 0 %}<th>Rating</th>{% endif %}
+                            {% if reviewed.size > 0 %}<th>Review</th>{% endif %}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for entry in books %}
+                        <tr>
+                            <td>{{ entry.title }}</td>
+                            <td>{{ entry.creator }}</td>
+                            {% if rated.size > 0 %}
+                            <td class="media-stars">{% include stars.html rating=entry.rating %}</td>
+                            {% endif %}
+                            {% if reviewed.size > 0 %}
+                            <td class="media-review">
+                                <span class="review-text">{{ entry.note }}</span>
+                                <span class="review-more">⋯</span>
+                            </td>
+                            {% endif %}
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </details>
+            {% endif %}
 
-        <h3>Books</h3>
-        <table class="styled-table">
-            <thead>
-                <tr>
-                    <th>Title</th>
-                    <th>Author</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>Play It As It Lays</td>
-                    <td>Joan Didion</td>
-                </tr>
-                <tr>
-                    <td>Jitterbug Perfume</td>
-                    <td>Tom Robbins</td>
-                </tr>
-                <tr>
-                    <td>Tenth of December: Stories</td>
-                    <td>George Saunders</td>
-                </tr>
-                <tr>
-                    <td>Scout Mindset</td>
-                    <td>Julia Galef</td>
-                </tr>
-                <tr>
-                    <td>The White Album</td>
-                    <td>Joan Didion</td>
-                </tr>
-                <tr>
-                    <td>Slouching Towards Bethlehem</td>
-                    <td>Joan Didion</td>
-                </tr>
-                <tr>
-                    <td>The Brief Wondrous Life of Oscar Wao</td>
-                    <td>Junot Diaz</td>
-                </tr>
-                <tr>
-                    <td>This is How You Lose Her</td>
-                    <td>Junot Diaz</td>
-                </tr>
-                <tr>
-                    <td>Wait for Signs</td>
-                    <td>Craig Johnson</td>
-                </tr>
-                <tr>
-                    <td>Song of Achilles</td>
-                    <td>Madeline Miller</td>
-                </tr>
-                <tr>
-                    <td>Circe</td>
-                    <td>Madeline Miller</td>
-                </tr>
-                <tr>
-                    <td>The Memory Police</td>
-                    <td>Yoko Ogawa</td>
-                </tr>
-                <tr>
-                    <td>Too Like the Lightning</td>
-                    <td>Ada Palmer</td>
-                </tr>
-            </tbody>
-        </table>
+            {% assign movies = year.items | where: "type", "movie" %}
+            {% if movies.size > 0 %}
+            {% assign rated = movies | where_exp: "item", "item.rating" %}
+            {% assign reviewed = movies | where_exp: "item", "item.note" %}
+            <details class="media-section" open>
+                <summary>
+                    <h3>Movies</h3>
+                    <small>{{ movies.size }}</small>
+                </summary>
+                <table class="styled-table">
+                    <thead>
+                        <tr>
+                            <th>Title</th>
+                            <th>Director</th>
+                            {% if rated.size > 0 %}<th>Rating</th>{% endif %}
+                            {% if reviewed.size > 0 %}<th>Review</th>{% endif %}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for entry in movies %}
+                        <tr>
+                            <td>{{ entry.title }}</td>
+                            <td>{{ entry.creator }}</td>
+                            {% if rated.size > 0 %}
+                            <td class="media-stars">{% include stars.html rating=entry.rating %}</td>
+                            {% endif %}
+                            {% if reviewed.size > 0 %}
+                            <td class="media-review">
+                                <span class="review-text">{{ entry.note }}</span>
+                                <span class="review-more">⋯</span>
+                            </td>
+                            {% endif %}
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </details>
+            {% endif %}
 
-        <h2>2021</h2>
-        <h3>Books</h3>
-        <table class="styled-table">
-            <thead>
-                <tr>
-                    <th>Title</th>
-                    <th>Author</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>1Q84</td>
-                    <td>Haruki Murakami</td>
-                </tr>
-                <tr>
-                    <td>Killing Commendatore</td>
-                    <td>Haruki Murakami</td>
-                </tr>
-                <tr>
-                    <td>In the Dream House</td>
-                    <td>Carmen Maria Machado</td>
-                </tr>
-                <tr>
-                    <td>Death's End</td>
-                    <td>Cixin Liu</td>
-                </tr>
-                <tr>
-                    <td>The Fifth Season</td>
-                    <td>N.K. Jemisin</td>
-                </tr>
-                <tr>
-                    <td>The Psychology of Money</td>
-                    <td>Morgan Housel</td>
-                </tr>
-                <tr>
-                    <td>Exhalation</td>
-                    <td>Ted Chiang</td>
-                </tr>
-                <tr>
-                    <td>The Obelisk Gate</td>
-                    <td>N.K. Jemisin</td>
-                </tr>
-                <tr>
-                    <td>The Stone Sky</td>
-                    <td>N.K. Jemisin</td>
-                </tr>
-                <tr>
-                    <td>Haskell Programming from First Principles</td>
-                    <td>Chris Allen and Julie Moronuki</td>
-                </tr>
-                <tr>
-                    <td>Vesper Flights</td>
-                    <td>Helen MacDonald</td>
-                </tr>
-                <tr>
-                    <td>Braiding Sweetgrass</td>
-                    <td>Robin Wall Kimmerer</td>
-                </tr>
-                <tr>
-                    <td>The Ninth House</td>
-                    <td>Leigh Bardugo</td>
-                </tr>
-                <tr>
-                    <td>Salat</td>
-                    <td>Dujie Tahat</td>
-                </tr>
-                <tr>
-                    <td>Amazon Unbound</td>
-                    <td>Brad Stone</td>
-                </tr>
-                <tr>
-                    <td>Abolish Silicon Valley</td>
-                    <td>Wendy Liu</td>
-                </tr>
-                <tr>
-                    <td>Version Zero</td>
-                    <td>David Yoon</td>
-                </tr>
-                <tr>
-                    <td>Zero to One</td>
-                    <td>Peter Thiel</td>
-                </tr>
-                <tr>
-                    <td>Zero In</td>
-                    <td>Dean Koontz</td>
-                </tr>
-                <tr>
-                    <td>Minor Problems</td>
-                    <td>Cathy Park Hong</td>
-                </tr>
-                <tr>
-                    <td>Here I Am O My God</td>
-                    <td>Dujie Tahat</td>
-                </tr>
-                <tr>
-                    <td>I'm Thinking of Ending Things</td>
-                    <td>Iain Reid</td>
-                </tr>
-                <tr>
-                    <td>Fingersmith</td>
-                    <td>Sarah Waters</td>
-                </tr>
-                <tr>
-                    <td>Homeland</td>
-                    <td>Corey Doctorow</td>
-                </tr>
-                <tr>
-                    <td>Attack Surface</td>
-                    <td>Corey Doctorow</td>
-                </tr>
-                <tr>
-                    <td>Blood Meridian</td>
-                    <td>Cormac McCarthy</td>
-                </tr>
-                <tr>
-                    <td>Draft No. 4: On the Writing Process</td>
-                    <td>John McPhee</td>
-                </tr>
-                <tr>
-                    <td>Capitalism without Capital</td>
-                    <td>Jonathan Haskel and Stian Westlake</td>
-                </tr>
-                <tr>
-                    <td>The Manager's Path</td>
-                    <td>Camille Fournier</td>
-                </tr>
-                <tr>
-                    <td>The Revolt of the Public</td>
-                    <td>Martin Gurri</td>
-                </tr>
-                <tr>
-                    <td>Working in Public</td>
-                    <td>Nadia Eghbal</td>
-                </tr>
-                <tr>
-                    <td>Fossil Capital</td>
-                    <td>Andreas Malm</td>
-                </tr>
-                <tr>
-                    <td>The Ministry for the Future</td>
-                    <td>Kim Stanley Robinson</td>
-                </tr>
-                <tr>
-                    <td>Bless Me, Ultima</td>
-                    <td>Rudolfo Anaya</td>
-                </tr>
-                <tr>
-                    <td>Slade House</td>
-                    <td>David Mitchell</td>
-                </tr>
-                <tr>
-                    <td>Averno</td>
-                    <td>Louise Gluck</td>
-                </tr>
-            </tbody>
-        </table>
-
-        <h2>2020</h2>
-        <h3>Books</h3>
-        <table class="styled-table">
-            <thead>
-                <tr>
-                    <th>Title</th>
-                    <th>Author</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>Men without Women</td>
-                    <td>Haruki Murakami</td>
-                </tr>
-                <tr>
-                    <td>Small Great Things</td>
-                    <td>Jodi Picoult</td>
-                </tr>
-                <tr>
-                    <td>Educated</td>
-                    <td>Tara Westover</td>
-                </tr>
-                <tr>
-                    <td>Little Fires Everywhere</td>
-                    <td>Celeste Ng</td>
-                </tr>
-                <tr>
-                    <td>Between the World and Me</td>
-                    <td>Ta-Nehisi Coates</td>
-                </tr>
-                <tr>
-                    <td>Hard-Boiled Wonderland and the End of the World</td>
-                    <td>Haruki Murakami</td>
-                </tr>
-                <tr>
-                    <td>The Order of Time</td>
-                    <td>Carlo Rovelli</td>
-                </tr>
-                <tr>
-                    <td>Sapiens</td>
-                    <td>Noah Yuval Harari</td>
-                </tr>
-                <tr>
-                    <td>Neuromancer</td>
-                    <td>William Gibson</td>
-                </tr>
-                <tr>
-                    <td>Little Brother (re-read)</td>
-                    <td>Cory Doctorow</td>
-                </tr>
-                <tr>
-                    <td>The Three-Body Problem</td>
-                    <td>Cixin Liu</td>
-                </tr>
-                <tr>
-                    <td>The Dark Forest</td>
-                    <td>Cixin Liu</td>
-                </tr>
-                <tr>
-                    <td>Burning Chrome</td>
-                    <td>William Gibson</td>
-                </tr>
-                <tr>
-                    <td>Count Zero</td>
-                    <td>William Gibson</td>
-                </tr>
-                <tr>
-                    <td>Release It!</td>
-                    <td>Michael T. Nygard</td>
-                </tr>
-                <tr>
-                    <td>Consider the Lobster and Other Essays</td>
-                    <td>David Foster Wallace</td>
-                </tr>
-                <tr>
-                    <td>On Writing</td>
-                    <td>Steven King</td>
-                </tr>
-                <tr>
-                    <td>Zen and the Art of Motorcycle Maintenance</td>
-                    <td>Robert M. Pirsig</td>
-                </tr>
-                <tr>
-                    <td>Why Nations Fail</td>
-                    <td>Daron Acemoglu and James A. Robinson</td>
-                </tr>
-                <tr>
-                    <td>Seinfeldia</td>
-                    <td>Jennifer Keishin Armstrong</td>
-                </tr>
-                <tr>
-                    <td>Dear Girls</td>
-                    <td>Ali Wong</td>
-                </tr>
-                <tr>
-                    <td>Can't Even</td>
-                    <td>Anne Helen Petersen</td>
-                </tr>
-                <tr>
-                    <td>Terranauts</td>
-                    <td>T.C. Boyle</td>
-                </tr>
-                <tr>
-                    <td>The Buried Giant</td>
-                    <td>Kazuo Ishiguro</td>
-                </tr>
-                <tr>
-                    <td>Liar's Poker</td>
-                    <td>Michael Lewis</td>
-                </tr>
-                <tr>
-                    <td>The New Wilderness</td>
-                    <td>Diane Cook</td>
-                </tr>
-                <tr>
-                    <td>The Attention Merchants</td>
-                    <td>Tim Wu</td>
-                </tr>
-                <tr>
-                    <td>The Southern Book Club's Guide to Slaying Vampires</td>
-                    <td>Grady Hendrix</td>
-                </tr>
-                <tr>
-                    <td>Leave the World Behind</td>
-                    <td>Rumaan Alam</td>
-                </tr>
-                <tr>
-                    <td>The Storied Life of A.J. Fikry</td>
-                    <td>Gabrielle Zevin</td>
-                </tr>
-                <tr>
-                    <td>Hot Water Music</td>
-                    <td>Charles Bukowski</td>
-                </tr>
-                <tr>
-                    <td>Out Stealing Horses</td>
-                    <td>Per Petterson</td>
-                </tr>
-                <tr>
-                    <td>Four in the Morning</td>
-                    <td>Sy Safransky</td>
-                </tr>
-                <tr>
-                    <td>The Neil Gaiman Reader: Selected Fiction</td>
-                    <td>Neil Gaiman</td>
-                </tr>
-            </tbody>
-        </table>
-
-        <h2>2019</h2>
-        <h3>Books</h3>
-        <table class="styled-table">
-            <thead>
-                <tr>
-                    <th>Title</th>
-                    <th>Author</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>All the Light We Cannot See</td>
-                    <td>Anthony Doerr</td>
-                </tr>
-                <tr>
-                    <td>The Gene</td>
-                    <td>Siddhartha Mukherjee</td>
-                </tr>
-                <tr>
-                    <td>High Output Management</td>
-                    <td>Andrew S. Grove</td>
-                </tr>
-                <tr>
-                    <td>American Gods</td>
-                    <td>Neil Gaiman</td>
-                </tr>
-                <tr>
-                    <td>Killers of the Flower Moon</td>
-                    <td>David Grann</td>
-                </tr>
-                <tr>
-                    <td>Border Songs</td>
-                    <td>Jim Lynch</td>
-                </tr>
-                <tr>
-                    <td>The Shortest Way Home</td>
-                    <td>Pete Buttigieg</td>
-                </tr>
-                <tr>
-                    <td>You Shall Know our Velocity!</td>
-                    <td>Dave Eggers</td>
-                </tr>
-                <tr>
-                    <td>Sirens of Titan</td>
-                    <td>Kurt Vonnegut</td>
-                </tr>
-                <tr>
-                    <td>REAMDE</td>
-                    <td>Neal Stephenson</td>
-                </tr>
-                <tr>
-                    <td>Redemption Road</td>
-                    <td>John Hart</td>
-                </tr>
-                <tr>
-                    <td>AI Superpowers</td>
-                    <td>Kai-Fu Lee</td>
-                </tr>
-                <tr>
-                    <td>The Overstory</td>
-                    <td>Richard Powers</td>
-                </tr>
-                <tr>
-                    <td>Pump Six and Other Stories</td>
-                    <td>Paolo Bacigalupi</td>
-                </tr>
-                <tr>
-                    <td>Where the Crawdads Sing</td>
-                    <td>Delia Owens</td>
-                </tr>
-                <tr>
-                    <td>Deep Work</td>
-                    <td>Cal Newport</td>
-                </tr>
-                <tr>
-                    <td>Digital Minimalism</td>
-                    <td>Cal Newport</td>
-                </tr>
-                <tr>
-                    <td>The Harder They Come</td>
-                    <td>TC Boyle</td>
-                </tr>
-                <tr>
-                    <td>The Remains of the Day</td>
-                    <td>Kazuo Ishiguro</td>
-                </tr>
-                <tr>
-                    <td>The Great Alone</td>
-                    <td>Kristin Hannah</td>
-                </tr>
-                <tr>
-                    <td>The Goldfinch</td>
-                    <td>Donna Tartt</td>
-                </tr>
-                <tr>
-                    <td>The Gift of Struggle</td>
-                    <td>Bob Herrera</td>
-                </tr>
-                <tr>
-                    <td>My Sister, the Serial Killer</td>
-                    <td>Oyinkan Braithwaite</td>
-                </tr>
-            </tbody>
-        </table>
+            {% assign other = year.items | where_exp: "item", "item.url == nil and item.type != 'book' and item.type != 'movie'" %}
+            {% if other.size > 0 %}
+            <details class="media-section" open>
+                <summary>
+                    <h3>Other</h3>
+                    <small>{{ other.size }}</small>
+                </summary>
+                <table class="styled-table">
+                    <thead>
+                        <tr>
+                            <th>Title</th>
+                            <th>Creator</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for entry in other %}
+                        <tr>
+                            <td>{{ entry.title }}</td>
+                            <td>{{ entry.creator }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </details>
+            {% endif %}
+        </details>
+        {% endfor %}
     </div>
 </div>
+
+<script>
+    (function () {
+        var input = document.getElementById("media-search");
+        var noResults = document.getElementById("media-no-results");
+        var years = Array.prototype.slice.call(
+            document.querySelectorAll(".media-year")
+        );
+        document
+            .querySelectorAll(".media-year, .media-section")
+            .forEach(function (el) {
+                el.dataset.defaultOpen = el.open ? "1" : "";
+            });
+
+        input.addEventListener("input", function () {
+            var query = input.value.trim().toLowerCase();
+            var anyMatch = false;
+
+            years.forEach(function (year) {
+                var yearMatches = 0;
+                year.querySelectorAll(".media-section").forEach(function (
+                    section
+                ) {
+                    var sectionMatches = 0;
+                    section
+                        .querySelectorAll("tbody tr")
+                        .forEach(function (item) {
+                            var hit =
+                                !query ||
+                                item.textContent
+                                    .toLowerCase()
+                                    .indexOf(query) !== -1;
+                            item.hidden = !hit;
+                            if (hit) sectionMatches++;
+                        });
+                    section.hidden = sectionMatches === 0;
+                    section.open = query
+                        ? sectionMatches > 0
+                        : section.dataset.defaultOpen === "1";
+                    yearMatches += sectionMatches;
+                });
+                year.hidden = query && yearMatches === 0;
+                year.open = query
+                    ? yearMatches > 0
+                    : year.dataset.defaultOpen === "1";
+                if (yearMatches > 0) anyMatch = true;
+            });
+
+            noResults.style.display = query && !anyMatch ? "block" : "none";
+        });
+
+        function detectClamps(root) {
+            root.querySelectorAll(".media-review").forEach(function (cell) {
+                if (cell.classList.contains("clampable")) return;
+                var text = cell.querySelector(".review-text");
+                if (text && text.scrollHeight > text.clientHeight + 1) {
+                    cell.classList.add("clampable");
+                }
+            });
+        }
+        detectClamps(document);
+        document
+            .querySelectorAll(".media-year, .media-section")
+            .forEach(function (el) {
+                el.addEventListener("toggle", function () {
+                    if (el.open) detectClamps(el);
+                });
+            });
+        document.addEventListener("click", function (e) {
+            var cell =
+                e.target.closest &&
+                e.target.closest(".media-review.clampable");
+            if (cell) cell.classList.toggle("expanded");
+        });
+    })();
+</script>

--- a/scripts/log
+++ b/scripts/log
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Log something you read/watched to the reading-log inbox (GitHub issues).
+#
+#   log <url> [note...]
+#   log "book: Blood Meridian — Cormac McCarthy" [note...]
+#   log "movie: Sinners — Ryan Coogler" finally saw it, incredible
+#   log "movie: Heat — Michael Mann" "4.5/5 the diner scene alone"   <- leading rating is parsed out
+#
+# A weekly GitHub Action turns open `log` issues into an archive PR.
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "usage: log <url | \"type: Title — Creator\"> [note...]" >&2
+  exit 1
+fi
+
+thing="$1"
+shift
+
+gh issue create -R dmarticus/dmarticus.github.io --label log --title "$thing" --body "${*:-}"

--- a/scripts/weekly-log.rb
+++ b/scripts/weekly-log.rb
@@ -1,0 +1,176 @@
+#!/usr/bin/env ruby
+# Turn open `log`-labeled issues into archive entries and a seeded digest draft.
+#
+# Usage: ruby scripts/weekly-log.rb issues.json
+# where issues.json is `gh issue list -l log --state open --json number,title,body,createdAt`
+#
+# Issue title conventions:
+#   https://...                a link (title is fetched from the page)
+#   book: Title — Author       a book; also movie:, show:, album:, podcast:, etc.
+#   anything else              logged as-is with type "misc"
+# The issue body is the note/review. It may start with a rating — "4/5",
+# "4.5/5", or "★★★★½" — which is stored separately.
+#
+# Appends to _data/log.yml, writes _digest/<date>-week-of-<...>.md, and emits
+# `count`, `closes`, and `digest_path` GitHub Actions outputs.
+
+require "json"
+require "yaml"
+require "net/http"
+require "uri"
+require "cgi"
+require "time"
+
+REPO_ROOT = File.expand_path("..", __dir__)
+LOG_PATH = File.join(REPO_ROOT, "_data", "log.yml")
+
+def fetch_page_title(url, limit = 5)
+  return nil if limit.zero?
+  uri = URI.parse(url)
+  return nil unless %w[http https].include?(uri.scheme)
+
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = uri.scheme == "https"
+  http.open_timeout = 10
+  http.read_timeout = 10
+  response = http.get(uri.request_uri, { "User-Agent" => "dylanamartin.com reading-log bot" })
+
+  case response
+  when Net::HTTPRedirection
+    location = URI.join(url, response["location"]).to_s
+    fetch_page_title(location, limit - 1)
+  when Net::HTTPSuccess
+    body = response.body.force_encoding(Encoding::UTF_8).scrub
+    match = body.match(%r{<title[^>]*>(.*?)</title>}mi)
+    match && CGI.unescapeHTML(match[1].strip.gsub(/\s+/, " "))
+  end
+rescue StandardError
+  nil
+end
+
+def parse_link(url, date, note)
+  uri = URI.parse(url)
+  host = uri.host.to_s.sub(/\Awww\./, "")
+  entry = { "date" => date, "title" => nil, "url" => url, "note" => note }
+
+  case host
+  when "x.com", "twitter.com"
+    entry["type"] = "tweet"
+    user = uri.path.split("/").reject(&:empty?).first
+    entry["title"] = user ? "@#{user} on X" : "Post on X"
+  when "youtube.com", "youtu.be"
+    entry["type"] = "video"
+    entry["title"] = fetch_page_title(url) || host
+  else
+    entry["type"] = "article"
+    entry["title"] = fetch_page_title(url) || host
+  end
+  entry
+end
+
+def parse_typed(type, rest, date, note)
+  title, creator = rest.split(/\s+—\s+|\s+–\s+|\s+-\s+/, 2)
+  if creator.nil? && title =~ /\A(.+)\s+by\s+(.+)\z/i
+    title, creator = Regexp.last_match(1), Regexp.last_match(2)
+  end
+  entry = { "date" => date, "type" => type, "title" => title.strip }
+  entry["creator"] = creator.strip if creator
+  entry["note"] = note
+  entry
+end
+
+def parse_rating(note)
+  return [nil, note] unless note
+
+  if note =~ %r{\A(\d(?:\.\d)?)\s*/\s*5\b[\s—–:,-]*}
+    [Regexp.last_match(1).to_f, note[Regexp.last_match(0).length..]]
+  elsif note =~ /\A(★{1,5})(½)?[\s—–:,-]*/
+    [Regexp.last_match(1).length + (Regexp.last_match(2) ? 0.5 : 0.0), note[Regexp.last_match(0).length..]]
+  else
+    [nil, note]
+  end
+end
+
+def stars(rating)
+  "★" * rating.floor + (rating % 1 >= 0.5 ? "½" : "")
+end
+
+def parse_issue(issue)
+  raw = issue["title"].strip
+  note = issue["body"].to_s.strip
+  note = nil if note.empty?
+  rating, note = parse_rating(note)
+  note = nil if note && note.strip.empty?
+  note = note.strip if note
+  date = issue["createdAt"][0, 10]
+
+  entry =
+    if raw =~ %r{\Ahttps?://}
+      parse_link(raw, date, note)
+    elsif raw =~ /\A(\w+):\s*(.+)\z/
+      parse_typed(Regexp.last_match(1).downcase, Regexp.last_match(2), date, note)
+    else
+      { "date" => date, "type" => "misc", "title" => raw, "note" => note }
+    end
+  entry["rating"] = rating if rating
+  entry = entry.compact
+  # Normalize key order so appended YAML matches the existing file's shape.
+  ordered = %w[date type title url creator rating note].each_with_object({}) do |key, acc|
+    acc[key] = entry[key] if entry.key?(key)
+  end
+  ordered.merge("issue" => issue["number"])
+end
+
+def digest_bullet(entry)
+  rating = entry["rating"] ? " #{stars(entry["rating"])}" : ""
+  note = entry["note"] ? " — #{entry["note"]}" : ""
+  if entry["url"]
+    "* [#{entry["title"]}](#{entry["url"]})#{note}"
+  elsif entry["creator"]
+    "* *#{entry["title"]}* by #{entry["creator"]} (#{entry["type"]})#{rating}#{note}"
+  else
+    "* #{entry["title"]} (#{entry["type"]})#{rating}#{note}"
+  end
+end
+
+def set_output(key, value)
+  if ENV["GITHUB_OUTPUT"]
+    File.open(ENV["GITHUB_OUTPUT"], "a") { |f| f.puts "#{key}=#{value}" }
+  end
+  puts "#{key}=#{value}"
+end
+
+issues = JSON.parse(File.read(ARGV.fetch(0)))
+if issues.empty?
+  set_output("count", 0)
+  exit
+end
+
+entries = issues.map { |issue| parse_issue(issue) }.sort_by { |e| e["date"] }
+issue_numbers = entries.map { |e| e.delete("issue") }
+
+# Append to the archive. Plain text append (not a YAML round-trip) so the
+# file's comments and existing formatting survive.
+yaml = entries.to_yaml.sub(/\A---\n/, "")
+File.write(LOG_PATH, File.read(LOG_PATH).chomp + "\n" + yaml)
+
+# Seed the digest draft for this week.
+today = Time.now.utc
+week_start = today - 6 * 86_400
+slug = "#{today.strftime("%Y-%m-%d")}-week-of-#{week_start.strftime("%B-%-d").downcase}"
+digest_path = File.join(REPO_ROOT, "_digest", "#{slug}.md")
+
+File.write(digest_path, <<~DIGEST)
+  ---
+  title: "Week of #{week_start.strftime("%B %-d, %Y")}"
+  layout: post
+  tags: []
+  summary: "TODO: a sentence or two about this week's highlights. Trim the list below to the favorites and punch up the notes — or delete this file from the PR to skip the digest this week."
+  ---
+
+  #{entries.map { |e| digest_bullet(e) }.join("\n")}
+DIGEST
+
+set_output("count", entries.length)
+set_output("closes", issue_numbers.map { |n| "Closes ##{n}" }.join(", "))
+set_output("digest_path", digest_path.sub("#{REPO_ROOT}/", ""))


### PR DESCRIPTION
## What this is

A two-layer consumption-tracking pipeline: an automatic archive of everything I read/watch, and a weekly curated digest seeded from it.

### Archive (`_data/log.yml`)
Single source of truth, 421 entries backfilled from:
- the old media page tables (books + movies, year-only dates)
- every link from all 21 past `_digest` posts (with original commentary as notes)
- Letterboxd diary via RSS (31 films: watch dates, ratings, reviews; also fixes the One Battle After Another director credit — it's PTA, not Nick Cassavetes)

### Media page (`media.html`)
Now rendered from the archive: collapsible years and sections with entry counts, client-side search across titles/creators/reviews, star ratings with a proper clipped half-star glyph, and two-line-clamped reviews with `⋯` click-to-expand.

### Weekly automation
- **Capture**: create a GitHub issue with the `log` label (title = URL or `book: Title — Author`; body = optional note, leading `4.5/5` or `★★★★½` parsed as a rating). `scripts/log` is a one-liner CLI wrapper.
- **`.github/workflows/weekly-log.yml`**: Sunday cron runs `scripts/weekly-log.rb`, which fetches page titles, appends everything to the archive, seeds a digest draft in `_digest/`, and opens a PR whose body closes the logged issues on merge. Curation = editing the draft in that PR (or deleting it to skip a week).

🤖 Generated with [Claude Code](https://claude.com/claude-code)