### PR TITLE
Drop the review expand button on the media page

### DIFF
--- a/media.html
+++ b/media.html
@@ -71,15 +71,6 @@ redirect_from:
     .media-review.clampable {
         cursor: pointer;
     }
-    .review-more {
-        display: none;
-        color: var(--text-secondary);
-        font-size: 0.8em;
-        user-select: none;
-    }
-    .media-review.clampable .review-more {
-        display: inline;
-    }
     .media-no-results {
         color: var(--text-secondary);
         display: none;
@@ -176,7 +167,6 @@ redirect_from:
                             {% if reviewed.size > 0 %}
                             <td class="media-review">
                                 <span class="review-text">{{ entry.note }}</span>
-                                <span class="review-more">⋯</span>
                             </td>
                             {% endif %}
                         </tr>
@@ -215,7 +205,6 @@ redirect_from:
                             {% if reviewed.size > 0 %}
                             <td class="media-review">
                                 <span class="review-text">{{ entry.note }}</span>
-                                <span class="review-more">⋯</span>
                             </td>
                             {% endif %}
                         </tr>


### PR DESCRIPTION
The review column's line-clamp already renders a native trailing ellipsis, so the separate expand indicator (`⋯`, later `+`/`−`) showed dots twice — once at the end of the clamped line and again on its own line.

This removes the indicator span and its CSS entirely. Clamped reviews still end with the native `…`, and clicking anywhere in the review cell (pointer cursor) still toggles the full text.

Based on `reading-log` since the media page lives there and isn't on master yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)